### PR TITLE
Disable pagination on status.cgi output

### DIFF
--- a/Nagstamon/Nagstamon/Server/Generic.py
+++ b/Nagstamon/Nagstamon/Server/Generic.py
@@ -158,11 +158,11 @@ class GenericServer(object):
         #hostserviceprops = 0
 
         # services (unknown, warning or critical?) as dictionary, sorted by hard and soft state type
-        self.cgiurl_services = {"hard": self.monitor_cgi_url + "/status.cgi?host=all&servicestatustypes=253&serviceprops=262144",\
-                                 "soft": self.monitor_cgi_url + "/status.cgi?host=all&servicestatustypes=253&serviceprops=524288"}
+        self.cgiurl_services = {"hard": self.monitor_cgi_url + "/status.cgi?host=all&servicestatustypes=253&serviceprops=262144&limit=0",\
+                                 "soft": self.monitor_cgi_url + "/status.cgi?host=all&servicestatustypes=253&serviceprops=524288&limit=0"}
         # hosts (up or down or unreachable)
-        self.cgiurl_hosts = { "hard": self.monitor_cgi_url + "/status.cgi?hostgroup=all&style=hostdetail&hoststatustypes=12&hostprops=262144",\
-                              "soft": self.monitor_cgi_url + "/status.cgi?hostgroup=all&style=hostdetail&hoststatustypes=12&hostprops=524288"}
+        self.cgiurl_hosts = { "hard": self.monitor_cgi_url + "/status.cgi?hostgroup=all&style=hostdetail&hoststatustypes=12&hostprops=262144&limit=0",\
+                              "soft": self.monitor_cgi_url + "/status.cgi?hostgroup=all&style=hostdetail&hoststatustypes=12&hostprops=524288&limit=0"}
 
 
     def reset_HTTP(self):


### PR DESCRIPTION
This allows showing all alerts, since the latest versions of Nagios have enabled pagination on status.cgi. It simply appends &limit=0 to the end of the URLs defined in Generic.py, which solves an issue of limited alert display. It's been tested with Nagios version 3.5.0 , but has not yet been tested with older versions.
