### PR TITLE
Secure Password Storage Example

### DIFF
--- a/Nagstamon/Nagstamon/Config.py
+++ b/Nagstamon/Nagstamon/Config.py
@@ -323,7 +323,7 @@ class Config(object):
                 if servers[server].save_password == "False":
                     servers[server].password = ""
 		elif self.keyring_available:
-                    servers[server].password = keyring.get_password("Nagstamon.Password", servers[server].username) or ""
+                    servers[server].password = keyring.get_password("Nagstamon", servers[server].username + "@" + servers[server].monitor_url) or ""
                 else:
                     servers[server].password = self.DeObfuscate(servers[server].password)
                 # do only deobfuscating if any autologin_key is set - will be only Centreon
@@ -478,7 +478,7 @@ class Config(object):
                                  value = ""
                                elif self.keyring_available:
                                  if self.__dict__[settingsdir][s].password != "":
-                                   keyring.set_password("Nagstamon.Password", self.__dict__[settingsdir][s].username, self.__dict__[settingsdir][s].password)
+                                   keyring.set_password("Nagstamon", self.__dict__[settingsdir][s].username + "@" + self.__dict__[settingsdir][s].monitor_url, self.__dict__[settingsdir][s].password)
                                  value = ""
                             config.set(setting + "_" + s, option, value)
                         else:


### PR DESCRIPTION
As per [issue 66](https://github.com/HenriWahl/Nagstamon/issues/66).

Below is a working example of the changes I made to implement secure password storage. The changes have been tidied up to not be such a nasty hack.

The keyring_available flag is set if the keyring module is available for import on the user's system AND a suitable default implementation for secure storage of credentials exists.

The main load & save server config sections have been modified to use the keyring module for secure password storage if available (ensuring an empty string is written to the config file for the password). If the module is not available then the current obfuscation implementation will be used. If the user does not enable the save password option then nothing will be stored using either method.

Note the or "" on line 326 is necessary for Nagstamon to handle the case where the keyring should be used but no password has yet been saved to the user's credential store. As a matter of personal preference I've disabled storage of empty password values to the keyring.
