### PR TITLE
Server/op5Monitor.py: add webbrowser support

### DIFF
--- a/Nagstamon/Nagstamon/Server/op5Monitor.py
+++ b/Nagstamon/Nagstamon/Server/op5Monitor.py
@@ -22,6 +22,7 @@ import json
 import urllib
 import datetime
 import time
+import webbrowser
 
 from datetime import datetime
 


### PR DESCRIPTION
To be able to click on an object and choose "Monitor" we need the
webbrowser module loaded.

Change-Id: I6572006efbcc85f62fadc2704b64d66f91f1122f
Signed-off-by: Mattias Ryrlén mattiasr@op5.com
