### PR TITLE
Manage multiple event notif

### DIFF
--- a/Nagstamon/Nagstamon/GUI.py
+++ b/Nagstamon/Nagstamon/GUI.py
@@ -1242,12 +1242,16 @@ class GUI(object):
 
                         # Notification actions
                         if str(self.conf.notification_actions) == "True":
-                            if str(self.conf.notification_action_warning) == "True":
-                                Actions.RunNotificationAction(str(self.conf.notification_action_warning_string))
-                            if str(self.conf.notification_action_critical) == "True":
-                                Actions.RunNotificationAction(str(self.conf.notification_action_critical_string))
-                            if str(self.conf.notification_action_down) == "True":
-                                Actions.RunNotificationAction(str(self.conf.notification_action_down_string))
+                            for event in [k for k,v in self.events_notification.items() if v == True]:
+                                if str(self.conf.notification_action_warning) == "True":
+                                    action_warning_string = self.conf.notification_action_warning_string.replace("$EVENT$", event)
+                                    Actions.RunNotificationAction(action_warning_string)
+                                if str(self.conf.notification_action_critical) == "True":
+                                    action_critical_string = self.conf.notification_action_critical_string.replace("$EVENT$", event)
+                                    Actions.RunNotificationAction(action_critical_string)
+                                if str(self.conf.notification_action_down) == "True":
+                                    action_down_string = self.conf.notification_action_down_string.replace("$EVENT$", event)
+                                    Actions.RunNotificationAction(action_down_string)
 
                         # if desired pop up status window
                         # sorry but does absolutely not work with windows and systray icon so I prefer to let it be

--- a/Nagstamon/Nagstamon/GUI.py
+++ b/Nagstamon/Nagstamon/GUI.py
@@ -1244,13 +1244,13 @@ class GUI(object):
                         if str(self.conf.notification_actions) == "True":
                             for event in [k for k,v in self.events_notification.items() if v == True]:
                                 if str(self.conf.notification_action_warning) == "True":
-                                    action_warning_string = self.conf.notification_action_warning_string.replace("$EVENT$", event)
+                                    action_warning_string = self.conf.notification_action_warning_string.replace("$EVENTS$", event)
                                     Actions.RunNotificationAction(action_warning_string)
                                 if str(self.conf.notification_action_critical) == "True":
-                                    action_critical_string = self.conf.notification_action_critical_string.replace("$EVENT$", event)
+                                    action_critical_string = self.conf.notification_action_critical_string.replace("$EVENTS$", event)
                                     Actions.RunNotificationAction(action_critical_string)
                                 if str(self.conf.notification_action_down) == "True":
-                                    action_down_string = self.conf.notification_action_down_string.replace("$EVENT$", event)
+                                    action_down_string = self.conf.notification_action_down_string.replace("$EVENTS$", event)
                                     Actions.RunNotificationAction(action_down_string)
 
                         # if desired pop up status window


### PR DESCRIPTION
Actually, the replacement of "$EVENTS$" in WARNING/CRITICAL/DOWN notifications doesn't work.
I simply add the "for" loop (already existing for custom actions).