### PR TITLE
Ugly fix for uncaught exceptions in Zabbix code. Needs more work.

### DIFF
--- a/Nagstamon/Nagstamon/thirdparty/zabbix_api.py
+++ b/Nagstamon/Nagstamon/thirdparty/zabbix_api.py
@@ -271,7 +271,7 @@ class ZabbixAPI(object):
         try:
             response = opener.open(request, timeout=self.timeout)
             self.debug(logging.INFO, "Response Code: " + str(response.code))
-        except urllib2.URLError:
+        except:
             #raise ZabbixAPIException("Could not open URL <%s>" % response.url)
             raise ZabbixAPIException("Could not open URL")
 
@@ -280,7 +280,11 @@ class ZabbixAPI(object):
         if response.code != 200:
             raise ZabbixAPIException("HTTP ERROR %s: %s"
                     % (response.status, response.reason))
-        reads = response.read()
+        try:
+            reads = response.read()
+        except:
+            raise ZabbixAPIException("Could not read response data.")
+
         if len(reads) == 0:
             raise ZabbixAPIException("Received zero answer")
         try:


### PR DESCRIPTION
At the moment some exceptions are not caught in the Zabbix plugin. On the other end there is a ZabbixError exception defined which nothing raises AFAICT. I guess the idea would be to catch all ZabbixAPIExceptions and turn them into ZabbixErrors?

I'm afraid this requires more time and skill than I have at the moment. Nevertheless, here is a quick and dirty patch which fixes a few real-life crashes (encountered with an unreliable network connection, where the Zabbix API requests can and do time out). I know ths patch is dirty and still needs a lot of work before merging, but it works for me.
