### PR TITLE
Pluggable servers support

### DIFF
--- a/Nagstamon/Nagstamon/Custom.py
+++ b/Nagstamon/Nagstamon/Custom.py
@@ -21,7 +21,12 @@
 columns and other stuff.
 Imported in GUI module.
 """
+
 from Nagstamon.Actions import register_server
+
+import logging
+log = logging.getLogger('nagstamon')
+
 
 # moved registration process because of circular dependencies
 # order of registering affects sorting in server type list in add new server dialog
@@ -29,6 +34,10 @@ from Nagstamon.Actions import register_server
 import pkg_resources
 
 for ep in sorted(pkg_resources.iter_entry_points('nagstamon.servers'), key=lambda x: x.name):
-    cls = ep.load()
-    register_server(cls)
+    try:
+        cls = ep.load()
+    except ImportError, e:
+        log.error('Can\'t load `%s` plugin', ep, exc_info=e)
+    else:
+        register_server(cls)
 

--- a/Nagstamon/Nagstamon/Custom.py
+++ b/Nagstamon/Nagstamon/Custom.py
@@ -23,24 +23,12 @@ Imported in GUI module.
 """
 from Nagstamon.Actions import register_server
 
-from Nagstamon.Server.Nagios import NagiosServer
-from Nagstamon.Server.Centreon import CentreonServer
-from Nagstamon.Server.Icinga import IcingaServer
-from Nagstamon.Server.Multisite import MultisiteServer
-from Nagstamon.Server.op5Monitor import Op5MonitorServer
-from Nagstamon.Server.Opsview import OpsviewServer
-from Nagstamon.Server.Thruk import ThrukServer
-from Nagstamon.Server.Zabbix import ZabbixServer
-
-
 # moved registration process because of circular dependencies
 # order of registering affects sorting in server type list in add new server dialog
-register_server(NagiosServer)
-register_server(CentreonServer)
-register_server(MultisiteServer)
-register_server(IcingaServer)
-register_server(Op5MonitorServer)
-register_server(OpsviewServer)
-register_server(ThrukServer)
-register_server(ZabbixServer)
+
+import pkg_resources
+
+for ep in sorted(pkg_resources.iter_entry_points('nagstamon.servers'), key=lambda x: x.name):
+    cls = ep.load()
+    register_server(cls)
 

--- a/Nagstamon/setup.py
+++ b/Nagstamon/setup.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 
-from distutils.core import setup
+from setuptools import setup
 import sys
 
 CLASSIFIERS = [
@@ -37,7 +37,7 @@ CLASSIFIERS = [
 ]
 
 setup(name = 'nagstamon',
-    version = '1.0.1',
+    version = '1.1.0',
     license = 'GNU GPL v2',
     description = 'Nagios status monitor for desktop',
     long_description = 'Nagstamon is a Nagios status monitor which takes place in systray or on desktop (GNOME, KDE, Windows) as floating statusbar to inform you in realtime about the status of your Nagios and derivatives monitored network. It allows to connect to multiple Nagios, Icinga, Opsview, Op5Monitor, Check_MK/Multisite, Centreon and Thruk servers.',
@@ -46,10 +46,22 @@ setup(name = 'nagstamon',
     author_email = 'h.wahl@ifw-dresden.de',
     url = 'https://nagstamon.ifw-dresden.de',
     download_url = 'https://nagstamon.ifw-dresden.de/files-nagstamon/stable/',
+    dependency_links = ['setuptools'],
     scripts = ['nagstamon.py'],
     packages = ['Nagstamon', 'Nagstamon.Server', 'Nagstamon.thirdparty'],
     package_dir = {'Nagstamon':'Nagstamon'},
     package_data = {'Nagstamon':['resources/*']},
+    entry_points = '''
+        [nagstamon.servers]
+        Nagios = Nagstamon.Server.Nagios:NagiosServer
+        Centreon = Nagstamon.Server.Centreon:CentreonServer
+        Multisite = Nagstamon.Server.Multisite:MultisiteServer
+        Icinga = Nagstamon.Server.Icinga:IcingaServer
+        op5Monitor = Nagstamon.Server.op5Monitor:Op5MonitorServer
+        Opsview = Nagstamon.Server.Opsview:OpsviewServer
+        Thruk = Nagstamon.Server.Thruk:ThrukServer
+        Zabbix = Nagstamon.Server.Zabbix:ZabbixServer
+        Ninja = Nagstamon.Server.Ninja:NinjaServer
+    ''',
     data_files = [('%s/share/man/man1' % sys.prefix, ['Nagstamon/resources/nagstamon.1'])]
 )
-

--- a/README.md
+++ b/README.md
@@ -1,20 +1,7 @@
 Nagstamon
 =========
 
-**Major development at the moment only happens in the '2.0' branch.**
-
-
-v2.0 Roadmap (by Marcin Nowak)
-------------------------------
- 
- - [ ] pluggable Servers using setuptool`s entry points
- - [ ] code cleanup 
- - [ ] define new&clean Server`s public interface and create real abstract BaseServer class
- - [ ] compatibility layer for old GenericServer
-
-
-Further notes
--------------
+**Major development at the moment only happens in the 'qt' branch.**
 
 To make this work on Yosemite:
 * brew install gtk-mac-integration

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 Nagstamon
 =========
 
-**Major development at the moment only happens in the 'qt' branch.**
+**Major development at the moment only happens in the '2.0' branch.**
+
+
+v2.0 Roadmap (by Marcin Nowak)
+------------------------------
+ 
+ - [ ] pluggable Servers using setuptool`s entry points
+ - [ ] code cleanup 
+ - [ ] define new&clean Server`s public interface and create real abstract BaseServer class
+ - [ ] compatibility layer for old GenericServer
+
+
+Further notes
+-------------
 
 To make this work on Yosemite:
 * brew install gtk-mac-integration


### PR DESCRIPTION
Hello.

I would like to use Nagstamon to read state of services fom uncommon monitoring tool. It would be nice to register a Server component outside of Nagstamon.

That's why I've changed explicite servers registration to iteration over defined entry points (using entry point group `nagstamon.servers`). That gives possibility to register custom server by an external package, which solve my needs.

Side effects of this pull requests:
  * `setuptools` used instead of `distutils`, because `distutils` does not support entry points
  * servers list order was changed (in combobox)
  * invalid entry point (missing class or other error) will **NOT** break Nagstamon startup (ImportError catched); bad plugin should not crash whole app, so error is just logged