### PR TITLE
Do not remember old unacknowledged events in Zabbix.

### DIFF
--- a/Nagstamon/Nagstamon/Server/Zabbix.py
+++ b/Nagstamon/Nagstamon/Server/Zabbix.py
@@ -197,11 +197,11 @@ class ZabbixServer(GenericServer):
                                     if int(x['internal']) == 0]
 
                     zabbix_triggers = self.zapi.trigger.get(
-                        {'sortfield': 'lastchange', 'withUnacknowledgedEvents': True, 'groupids': hostgroup_ids,
+                        {'sortfield': 'lastchange', 'withLastEventUnacknowledged': True, 'groupids': hostgroup_ids,
                          "monitored": True, "filter": {'value': 1}})
                 else:
                     zabbix_triggers = self.zapi.trigger.get(
-                        {'sortfield': 'lastchange', 'withUnacknowledgedEvents': True, "monitored": True,
+                        {'sortfield': 'lastchange', 'withLastEventUnacknowledged': True, "monitored": True,
                          "filter": {'value': 1}})
                 triggers_list = []
 


### PR DESCRIPTION
The Zabbix API has a withUnacknowledgedEvents flag which returns triggers with unacknowledged event sometime in their history. All we really care about is the current state of the trigger, not its whole history.

This has been tested with Zabbix 2.2; I don't have access to earlier versions.