### PR TITLE
Added LinuxMint to target dists

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -208,6 +208,7 @@ def rpmmain():
 DISTS = {
     'debian': debmain,
     'Ubuntu': debmain,
+    'LinuxMint': debmain,
     'fedora': rpmmain
 }
 


### PR DESCRIPTION
This is to allow the DEB to build on LinuxMint 17, which is basically the same as Ubuntu 14.04 LTS.