### PR TITLE
do not initialize python logging

### DIFF
--- a/Nagstamon/Nagstamon/Servers/Livestatus.py
+++ b/Nagstamon/Nagstamon/Servers/Livestatus.py
@@ -24,7 +24,6 @@ from Nagstamon.Servers.Generic import GenericServer
 from Nagstamon.Config import conf
 
 import logging
-logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger('Livestatus')
 
 import re
@@ -92,7 +91,6 @@ class LivestatusServer(GenericServer):
         log.debug('connecting')
         s.connect(self.address)
         s.send('\n'.join(data).encode('utf8'))
-        log.debug('response is %s', response)
         if not response:
             log.debug('no response required, disconnect')
             s.close()


### PR DESCRIPTION
do not initialize python logging in Livestatus. Just use it and rely on someone else to initialize it. Prepares for attaching logging to the nagstamon logger.