### PR TITLE
Add Zabbix 3.0 support

### DIFF
--- a/Nagstamon/Nagstamon/Server/Zabbix.py
+++ b/Nagstamon/Nagstamon/Server/Zabbix.py
@@ -245,7 +245,6 @@ class ZabbixServer(GenericServer):
                 else:
                     state = '%s=%s' % (service['items'][0]['key_'], service['items'][0]['lastvalue']) 
                 n = {
-                    'host': service['host'],
                     'service': service['description'],
                     'status': self.statemap.get(service['priority'], service['priority']),
                     # 1/1 attempt looks at least like there has been any attempt

--- a/Nagstamon/Nagstamon/Server/Zabbix.py
+++ b/Nagstamon/Nagstamon/Server/Zabbix.py
@@ -260,7 +260,7 @@ class ZabbixServer(GenericServer):
                     'triggerid': service['triggerid'],
                 }
 
-                if api_version > '3.0':
+                if api_version >= '3.0':
                     n['host'] = self.zapi.host.get({"output": ["host"], "filter": {}, "triggerids": service['triggerid']})[0]['host']
                 else:
                     n['host'] = service['host']

--- a/Nagstamon/Nagstamon/Server/Zabbix.py
+++ b/Nagstamon/Nagstamon/Server/Zabbix.py
@@ -261,6 +261,11 @@ class ZabbixServer(GenericServer):
                     'triggerid': service['triggerid'],
                 }
 
+                if api_version > '3.0':
+                    n['host'] = self.zapi.host.get({"output": ["host"], "filter": {}, "triggerids": service['triggerid']})[0]['host']
+                else:
+                    n['host'] = service['host']
+
                 nagitems["services"].append(n)
                 # after collection data in nagitems create objects of its informations
                 # host objects contain service objects


### PR DESCRIPTION
Hello!

Due to changes in Zabbix 3.0 API - added small patch.
Reason: removed ExpandData parameter in method trigger.get - https://support.zabbix.com/browse/ZBXNEXT-2724

Thanks.