### PR TITLE
Check_MK Multisite: Added server option to enforce AuthUser

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -731,6 +731,11 @@ class Server(object):
         self.use_display_name_host = False
         self.use_display_name_service = False
 
+        # Check_MK Multisite
+        # Force Check_MK livestatus code to set AuthUser header for users who
+        # are permitted to see all objects.
+        self.force_authuser = False
+
 
 class Action(object):
     """

--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -4318,7 +4318,8 @@ class Dialog_Server(Dialog):
                                  self.ui.input_lineedit_autologin_key : ['Centreon'],
                                  self.ui.label_autologin_key : ['Centreon'],
                                  self.ui.input_checkbox_use_display_name_host : ['Icinga', 'IcingaWeb2'],
-                                 self.ui.input_checkbox_use_display_name_service : ['Icinga', 'IcingaWeb2']
+                                 self.ui.input_checkbox_use_display_name_service : ['Icinga', 'IcingaWeb2'],
+                                 self.ui.input_checkbox_force_authuser : ['Check_MK Multisite'],
                                 }
 
         # fill default order fields combobox with monitor server types

--- a/Nagstamon/QUI/settings_server.py
+++ b/Nagstamon/QUI/settings_server.py
@@ -111,6 +111,9 @@ class Ui_settings_server(object):
         self.input_checkbox_use_display_name_service = QtWidgets.QCheckBox(settings_server)
         self.input_checkbox_use_display_name_service.setObjectName("input_checkbox_use_display_name_service")
         self.gridLayout.addWidget(self.input_checkbox_use_display_name_service, 22, 0, 1, 2)
+        self.input_checkbox_force_authuser = QtWidgets.QCheckBox(settings_server)
+        self.input_checkbox_force_authuser.setObjectName("input_checkbox_force_authuser")
+        self.gridLayout.addWidget(self.input_checkbox_force_authuser, 23, 0, 1, 2)
         self.input_checkbox_enabled = QtWidgets.QCheckBox(settings_server)
         self.input_checkbox_enabled.setObjectName("input_checkbox_enabled")
         self.gridLayout.addWidget(self.input_checkbox_enabled, 0, 0, 1, 3)
@@ -186,6 +189,7 @@ class Ui_settings_server(object):
         settings_server.setTabOrder(self.input_lineedit_proxy_password, self.input_checkbox_use_proxy_from_os)
         settings_server.setTabOrder(self.input_checkbox_use_proxy_from_os, self.input_checkbox_use_display_name_host)
         settings_server.setTabOrder(self.input_checkbox_use_display_name_host, self.input_checkbox_use_display_name_service)
+        settings_server.setTabOrder(self.input_checkbox_force_authuser, self.input_checkbox_force_authuser)
 
     def retranslateUi(self, settings_server):
         _translate = QtCore.QCoreApplication.translate
@@ -205,6 +209,8 @@ class Ui_settings_server(object):
         self.label_autologin_key.setText(_translate("settings_server", "Autologin Key:"))
         self.label_monitor_url.setText(_translate("settings_server", "Monitor URL:"))
         self.input_checkbox_use_display_name_service.setText(_translate("settings_server", "Use display name as service name"))
+        self.input_checkbox_force_authuser.setText(_translate("settings_server",
+                                                   "Only show permitted hosts for \"see all\" users (1.4.0i1 or newer)"))
         self.input_checkbox_enabled.setText(_translate("settings_server", "Enabled"))
         self.label_password.setText(_translate("settings_server", "Password:"))
         self.input_lineedit_username.setText(_translate("settings_server", "username"))

--- a/Nagstamon/QUI/settings_server.ui
+++ b/Nagstamon/QUI/settings_server.ui
@@ -203,6 +203,13 @@
      </property>
     </widget>
    </item>
+   <item row="23" column="0" colspan="2">
+    <widget class="QCheckBox" name="input_checkbox_force_authuser">
+     <property name="text">
+      <string>Only show permitted hosts for "see all" users (1.4.0i1 or newer)</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="3">
     <widget class="QCheckBox" name="input_checkbox_enabled">
      <property name="text">

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -154,6 +154,8 @@ class GenericServer(object):
         # Icinga
         self.use_display_name_host = False
         self.use_display_name_service = False
+        # Check_MK Multisite
+        self.force_authuser = False
 
 
     def init_config(self):

--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -197,6 +197,9 @@ class MultisiteServer(GenericServer):
         # Create URLs for the configured filters
         url_params = ''
 
+        if self.force_authuser:
+            url_params += "&force_authuser=1"
+
         url_params += '&is_host_acknowledged=-1&is_service_acknowledged=-1'
         url_params += '&is_host_notifications_enabled=-1&is_service_notifications_enabled=-1'
         url_params += '&is_host_active_checks_enabled=-1&is_service_active_checks_enabled=-1'

--- a/Nagstamon/Servers/__init__.py
+++ b/Nagstamon/Servers/__init__.py
@@ -142,6 +142,8 @@ def create_server(server=None):
     # Icinga
     new_server.use_display_name_host = server.use_display_name_host
     new_server.use_display_name_service = server.use_display_name_service
+    # Check_MK Multisite
+    new_server.force_authuser = server.force_authuser
 
     # server's individual preparations for HTTP connections (for example cookie creation)
     # is done in GetStatus() method of monitor


### PR DESCRIPTION
When a user which is permitted to see all hosts/services in Check_MK
Multisite is used from Nagstamon it displays the problems of all
hosts/services.

Some admin users only want to see "their" hosts. These are the hosts
they are assigned with as contact.

Since Check_MK 1.4.0i1 the new option to "show only permitted hosts"
is supported by Check_MK.

Previous Check_MK versions had a user profile option named "Visibility of
Hosts/Services (Webservice)" to configure this. But this option has
been deprecated and will be removed in future releases. If you used this
option before you are adviced to disable it and enable the new option
in Nagstamon.