### PR TITLE
Added CLI parameter

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -28,16 +28,31 @@ import zlib
 import datetime
 from collections import OrderedDict
 
-from Nagstamon.Helpers import (debug_queue,
-                               BOOLPOOL,
-                               NON_LINUX)
+# avoid build error because of debug_queue unknown to setup.py
+# if anybody knows a more elegant way (which surely exists) let me know
+# it had to work quickly!
+if not 'setup.py' in sys.argv[0] and not 'build.py' in sys.argv[0]:
+    # get debug queue from nagstamon.py
+    debug_queue = sys.modules['__main__'].debug_queue
+
+
+# temporary dict for string-to-bool-conversion
+# the bool:bool relations are thought to make things easier in Dialog_Settings.ok()
+BOOLPOOL = {'False': False,
+            'True': True,
+            False: False,
+            True: True}
+
+# needed when OS-specific decisions have to be made, mostly Linux/non-Linux
+NON_LINUX = ('Darwin', 'Windows')
+
 
 class AppInfo(object):
     """
         contains app information previously located in GUI.py
     """
     NAME = 'Nagstamon'
-    VERSION = '2.0-alpha-20160308'
+    VERSION = '2.0-beta-20160509'
     WEBSITE = 'https://nagstamon.ifw-dresden.de'
     COPYRIGHT = '©2008-2016 Henri Wahl et al.\nh.wahl@ifw-dresden.de'
     COMMENTS = 'Nagios status monitor for your desktop'
@@ -57,8 +72,10 @@ class Config(object):
         self.update_interval_seconds = 60
         self.short_display = False
         self.long_display = True
-        self.show_grid = True
         self.show_tooltips = True
+        self.show_grid = True        
+        self.grid_use_custom_intensity = False
+        self.grid_alternation_intensity = 10
         self.highlight_new_events = True
         self.default_sort_field = 'status'
         self.default_sort_order = 'descending'
@@ -88,6 +105,9 @@ class Config(object):
         self.connect_by_host = True
         self.connect_by_dns = False
         self.connect_by_ip = False
+        self.use_default_browser = True
+        self.use_custom_browser = False
+        self.custom_browser = ''
         self.debug_mode = False
         self.debug_to_file = False
         self.debug_file = os.path.expanduser('~') + os.sep + "nagstamon.log"
@@ -143,7 +163,7 @@ class Config(object):
         self.color_unreachable_background = self.default_color_unreachable_background = '#8B0000'
         self.color_down_text = self.default_color_down_text = '#FFFFFF'
         self.color_down_background = self.default_color_down_background = '#000000'
-        self.color_error_text = self.default_color_error_text= '#000000'
+        self.color_error_text = self.default_color_error_text = '#000000'
         self.color_error_background = self.default_color_error_background = '#D3D3D3'
         self.statusbar_floating = True
         self.icon_in_systray = False
@@ -177,26 +197,42 @@ class Config(object):
         # the app is unconfigured by default and will stay so if it
         # would not find a config file
         self.unconfigured = True
+        self.cli_args = {}
 
         # Parse the command line
         parser = argparse.ArgumentParser(description='Nagios status monitor for your desktop')
-        parser.add_argument('cfgpath', nargs='?', help='Path for configuration folder')
+        
         # might be not necessary anymore - to be tested
-        ###parser.add_argument('-psn', action='store_true',
-        ###    help='force ~/.nagstamon as config folder (used by launchd in MacOSX)')
+        # ##parser.add_argument('-psn', action='store_true',
+        # ##    help='force ~/.nagstamon as config folder (used by launchd in MacOSX)')
         # necessary because otherwise setup.py goes crazy of argparse
-        args, unknown = parser.parse_known_args()
-
+        
+        # separate NagstaCLI from 
+        if len(sys.argv) > 2:                        
+            parser.add_argument('--servername', type=str, help="name of the (Nagios)server. Look in nagstamon config")
+            parser.add_argument('--hostname', type=str)    
+            parser.add_argument('--comment', type=str, default="")
+            parser.add_argument('--service', type=str, default="", help="specify service, if needed. Mostly the whole host goes to downstate")
+            parser.add_argument('--fixed', type=str, choices=['y', 'n'], default="y", help="fixed=n means wait for service/host to go down, then start the downtime")
+            parser.add_argument('--start_time', type=str, help="start time for downtime")
+            parser.add_argument('--hours', type=int, help="amount of hours for downtime")
+            parser.add_argument('--minutes', type=int, help="amount of minutes for downtime")
+            parser.add_argument('--configfolder', type=str, help="Path for configuration folder")
+            parser.add_argument('--output', type=str, choices=['y', 'n'], default="y",help="lists given parameter (for debugging)")
+        else:
+            parser.add_argument('configfolder', nargs='?', help='Path for configuration folder')            
+        
+        self.cli_args, unknown = parser.parse_known_args()
+        
         # try to use a given config file - there must be one given
         # if sys.argv is larger than 1
-        ###if args.psn:
-        ###    # new configdir approach
-        ###    self.configdir = os.path.expanduser('~') + os.sep + '.nagstamon'
-        ###elif args.cfgpath:
-        if args.cfgpath:
+        # ##if args.psn:
+        # ##    # new configdir approach
+        # ##    self.configdir = os.path.expanduser('~') + os.sep + '.nagstamon'
+        # ##elif args.config:        
+        if len(sys.argv) < 3 and self.cli_args.configfolder:
             # allow to give a config file
-            self.configdir = args.cfgpath
-
+            self.configdir = self.cli_args.configfolder
         # otherwise if there exits a configdir in current working directory it should be used
         elif os.path.exists(os.getcwd() + os.sep + 'nagstamon.config'):
             self.configdir = os.getcwd() + os.sep + 'nagstamon.config'
@@ -245,7 +281,7 @@ class Config(object):
                         # treat negative value specially as .isdecimal() will not detect it
                         elif i[1].isdecimal() or \
                              (i[1].startswith('-') and i[1].split('-')[1].isdecimal()):
-                            object.__setattr__(self, i[0],int(i[1]))
+                            object.__setattr__(self, i[0], int(i[1]))
                         else:
                             object.__setattr__(self, i[0], i[1])
 
@@ -253,7 +289,7 @@ class Config(object):
             # and all the thousands 1.0 installations do not know it yet it will be more comfortable
             # for most of the Windows users if it is only defined as False after it was checked
             # from config file
-            #if not self.__dict__.has_key("use_system_keyring"):
+            # if not self.__dict__.has_key("use_system_keyring"):
             if not 'use_system_keyring' in self.__dict__.keys():
                 if self.unconfigured == True:
                     # an unconfigured system should start with no keyring to prevent crashes
@@ -306,7 +342,7 @@ class Config(object):
                     servers[server].password = ""
                 elif self.keyring_available and self.use_system_keyring:
                     # necessary to import on-the-fly due to possible Windows crashes
-                    import keyring
+                    import Nagstamon.thirdparty.keyring as keyring
                     password = keyring.get_password('Nagstamon', '@'.join((servers[server].username,
                                                                            servers[server].monitor_url))) or ""
                     if password == "":
@@ -319,7 +355,7 @@ class Config(object):
                 # proxy password
                 if self.keyring_available and self.use_system_keyring:
                     # necessary to import on-the-fly due to possible Windows crashes
-                    import keyring
+                    import Nagstamon.thirdparty.keyring as keyring
                     proxy_password = keyring.get_password('Nagstamon', '@'.join(('proxy',
                                                                                  servers[server].proxy_username,
                                                                                  servers[server].proxy_address))) or ""
@@ -334,9 +370,9 @@ class Config(object):
                 # do only deobfuscating if any autologin_key is set - will be only Centreon
                 if 'autologin_key' in servers[server].__dict__.keys():
                     if len(servers[server].__dict__['autologin_key']) > 0:
-                        servers[server].autologin_key  = self.DeObfuscate(servers[server].autologin_key)
+                        servers[server].autologin_key = self.DeObfuscate(servers[server].autologin_key)
 
-                # only needed for those who used Icinga2 before it became icingaWeb2
+                # only needed for those who used Icinga2 before it became IcingaWeb2
                 if servers[server].type == 'Icinga2':
                     servers[server].type = 'IcingaWeb2'
 
@@ -349,7 +385,7 @@ class Config(object):
 
     def LoadMultipleConfig(self, settingsdir, setting, configobj):
         """
-        load generic config into settings dict and return to central config
+            load generic config into settings dict and return to central config
         """
         # defaults as empty dict in case settings dir/files could not be found
         settings = OrderedDict()
@@ -398,7 +434,7 @@ class Config(object):
             # general section for Nagstamon
             config.add_section('Nagstamon')
             for option in self.__dict__:
-                if not option in ['servers', 'actions', 'configfile', 'configdir']:
+                if not option in ['servers', 'actions', 'configfile', 'configdir', 'cli_args']:
                     config.set('Nagstamon', option, str(self.__dict__[option]))
 
             # because the switch from Nagstamon 1.0 to 1.0.1 brings the use_system_keyring property
@@ -457,7 +493,7 @@ class Config(object):
             for option in self.__dict__[settingsdir][s].__dict__:
                 # obfuscate certain entries in config file - special arrangement for servers
                 if settingsdir == 'servers':
-                    #if option == "username" or option == "password" or option == "proxy_username" or option == "proxy_password" or option == "autologin_key":
+                    # if option == "username" or option == "password" or option == "proxy_username" or option == "proxy_password" or option == "autologin_key":
                     if option in ['username', 'password', 'proxy_username', 'proxy_password', 'autologin_key']:
                         value = self.Obfuscate(self.__dict__[settingsdir][s].__dict__[option])
                         if option == 'password':
@@ -466,7 +502,7 @@ class Config(object):
                             elif self.keyring_available and self.use_system_keyring:
                                 if self.__dict__[settingsdir][s].password != '':
                                     # necessary to import on-the-fly due to possible Windows crashes
-                                    import keyring
+                                    import Nagstamon.thirdparty.keyring as keyring
                                     # provoke crash if password saving does not work - this is the case
                                     # on newer Ubuntu releases
                                     try:
@@ -481,12 +517,12 @@ class Config(object):
                         if option == 'proxy_password':
                             if self.keyring_available and self.use_system_keyring:
                                 # necessary to import on-the-fly due to possible Windows crashes
-                                import keyring
+                                import Nagstamon.thirdparty.keyring as keyring
                                 if self.__dict__[settingsdir][s].proxy_password != '':
                                     # provoke crash if password saving does not work - this is the case
                                     # on newer Ubuntu releases
                                     try:
-                                        keyring.set_password('Nagstamon', '@'.join(('proxy',\
+                                        keyring.set_password('Nagstamon', '@'.join(('proxy', \
                                                                                 self.__dict__[settingsdir][s].proxy_username,
                                                                                 self.__dict__[settingsdir][s].proxy_address)),
                                                                                 self.__dict__[settingsdir][s].proxy_password)
@@ -525,12 +561,13 @@ class Config(object):
             # that keyring works at all
             if not platform.system() in NON_LINUX:
                 # keyring and secretstorage have to be importable
-                import keyring, secretstorage
+                import Nagstamon.thirdparty.keyring as keyring
+                import secretstorage
                 if ("SecretService") in dir(keyring.backends) and not (keyring.get_keyring() is None):
                     return True
             else:
                 # safety first - if not yet available disable it
-                #if not self.__dict__.has_key("use_system_keyring"):
+                # if not self.__dict__.has_key("use_system_keyring"):
                 if not 'use_system_keyring' in self.__dict__.keys():
                     self.use_system_keyring = False
                 # only import keyring lib if configured to do so
@@ -538,7 +575,7 @@ class Config(object):
                 if self.use_system_keyring == True:
                     # hint for packaging: nagstamon.spec always have to match module path
                     # keyring has to be bound to object to be used later
-                    import keyring
+                    import Nagstamon.thirdparty.keyring as keyring
                     return  not (keyring.get_keyring() is None)
                 else:
                     return False
@@ -667,10 +704,8 @@ class Config(object):
     def _LegacyAdjustments(self):
         # mere cosmetics but might be more clear for future additions - changing any "nagios"-setting to "monitor"
         for s in self.servers.values():
-            ###if s.__dict__.has_key("nagios_url"):
             if 'nagios_url' in s.__dict__.keys():
                 s.monitor_url = s.nagios_url
-            ###if s.__dict__.has_key("nagios_cgi_url"):
             if 'nagios_cgi_url' in s.__dict__.keys():
                 s.monitor_cgi_url = s.nagios_cgi_url
 
@@ -689,6 +724,12 @@ class Config(object):
                 self.icon_in_systray = True
             self.__dict__.pop('statusbar_systray')
 
+        # some legacy action settings might need a little fix
+        for action in self.actions.values():
+            if not action.type.lower() in ('browser', 'command', 'url'):
+                # set browser as default to make user notice something is wrong
+                action.type = 'browser'
+        
 
     def GetNumberOfEnabledMonitors(self):
         """
@@ -697,7 +738,7 @@ class Config(object):
         # to be returned
         number = 0
         for server in self.servers.values():
-            ###if str(server.enabled) == "True":
+            # ##if str(server.enabled) == "True":
             if server.enabled == True:
                 number += 1
         return number
@@ -730,6 +771,11 @@ class Server(object):
         # Icinga "host_display_name" instead of "host"
         self.use_display_name_host = False
         self.use_display_name_service = False
+
+        # Check_MK Multisite
+        # Force Check_MK livestatus code to set AuthUser header for users who
+        # are permitted to see all objects.
+        self.force_authuser = False
 
 
 class Action(object):
@@ -808,10 +854,10 @@ except Exception as err:
     except:
         pass
 
-    #if we're still out of luck, maybe this was a user scheme install
+    # if we're still out of luck, maybe this was a user scheme install
     try:
         import site
-        site.getusersitepackages() #make sure USER_SITE is set
+        site.getusersitepackages()  # make sure USER_SITE is set
         paths_to_check.append(os.path.normcase(os.path.join(site.USER_SITE, "Nagstamon", "resources")))
     except:
         pass

--- a/nagstacli.py
+++ b/nagstacli.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+# Nagstamon - Nagios status monitor for your desktop
+# Copyright (C) 2008-2016 Henri Wahl <h.wahl@ifw-dresden.de> et al. Maik Lüdeke <m.luedeke@ifw-dresden.de>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+import sys
+import socket
+import datetime
+import re
+
+# fix/patch for https://bugs.launchpad.net/ubuntu/+source/nagstamon/+bug/732544
+socket.setdefaulttimeout(30)
+#checks if there is a current value for the variable, if not the default value will be returned
+def checkDefaultValue(value, default):
+    if value == None:
+        return default
+    else:
+        return value
+
+# extracts the time from the start_time and adds hours and minutes
+def createEndTime(info_dict):
+    
+    # extracts the time from arg 'start_time' 
+    # then adds the hours/minutes to the start_date and reassambles the string        
+    regex = re.compile('(.*)\s(\d{1,2})([\:\.])(\d{1,2})(.*)')
+    
+    time_string = re.search(regex, info_dict['start_time'])                                 
+    
+    start_hour = int(time_string.group(2))
+    separator = (time_string.group(3))
+    start_minute = int(time_string.group(4))
+    # if the time has a format like "12:12:53.122" the seconds and milliseconds were 
+    # extracted and then attached as string again
+    if (len(time_string.group()) == 6):
+        attached_timestring = int(time_string.group(5))
+    else:
+        attached_timestring = ""
+    #  calculate the hour/minutes for downtime. convert 120 minutes to 2 h or 90 minutes to 1 h 30 min 
+    hour, minute = divmod(info_dict['minutes'] + int(start_minute) + 
+                          (60 * (start_hour + info_dict['hours'])), 60)
+    
+    if hour > 23:
+        print("it is (at the moment) not possible to end the timer after 0:00 o`clock")
+        sys.exit(0)    
+    
+    info_dict['end_time'] = (time_string.group(1) + " " +
+                             str(hour)+separator+'{0:02d}'.format(minute)+attached_timestring)  
+    
+    return info_dict
+
+def executeCli():
+    from Nagstamon.Config import (conf,
+                          Server,
+                          Action,
+                          RESOURCES,
+                          AppInfo
+                          )
+    
+    from Nagstamon.Servers import (SERVER_TYPES,
+                           servers,
+                           create_server,
+                           get_enabled_servers,
+                           get_worst_status,
+                           get_status_count,
+                           get_errors)    
+      
+    # Initialize global configuration
+                                
+    from Nagstamon.Objects import (GenericHost)
+    
+    #creates new server object from given servername
+    server = create_server(conf.servers[conf.cli_args.servername])
+    
+    # gets the current default start/endtime from the server (default current time + 2h)
+    start_end_time = server.get_start_end(conf.cli_args.hostname)
+    default_start_time = start_end_time[0]
+    default_end_time = start_end_time[1]
+    #gets the default downtime duration from the nagstamon config
+    default_downtime = conf.defaults_downtime_duration_minutes
+    
+    server.GetStatus()    
+            
+    server.hosts[conf.cli_args.hostname] = GenericHost()
+    server.hosts[conf.cli_args.hostname].name = conf.cli_args.hostname
+    server.hosts[conf.cli_args.hostname].server = server.name
+    server.hosts[conf.cli_args.hostname].site = "monitor"    
+    
+    fixedType = {"y": True, "n": False}
+    
+    info_dict = dict()
+    info_dict['host'] = conf.cli_args.hostname 
+    info_dict['service'] = conf.cli_args.service
+    info_dict['author'] = server.username
+    info_dict['comment'] = conf.cli_args.comment
+    info_dict['fixed'] = fixedType[conf.cli_args.fixed]    
+        
+    info_dict['start_time'] = checkDefaultValue(conf.cli_args.start_time, default_start_time)
+    info_dict['end_time'] = default_end_time
+    
+    info_dict['hours'] = checkDefaultValue(conf.cli_args.hours, conf.defaults_downtime_duration_hours)
+    info_dict['minutes'] = checkDefaultValue(conf.cli_args.minutes, conf.defaults_downtime_duration_minutes)
+    info_dict['view_name'] = "host"
+    
+    info_dict = createEndTime(info_dict)
+    #creates output,v which parameter were processed  
+    if conf.cli_args.output == 'y':
+        print('trying to downtime host "' + info_dict['host'] + '", with the following parameters:')
+        if info_dict['service'] != "":
+            print('service: ', info_dict['service'])
+        if info_dict['comment'] != None:
+            print('comment: ', info_dict['comment'])        
+        print('fixed: ', info_dict['fixed'])
+        print('start time: ', info_dict['start_time'])
+        print('end time: ', info_dict['end_time'])          
+    
+    server.set_downtime(info_dict)    
+
+try:
+    if __name__ == '__main__':
+        debug_queue = list()
+        executeCli()
+        
+
+except Exception as err:
+    import traceback
+    traceback.print_exc(file=sys.stdout)

--- a/nagstamon.py
+++ b/nagstamon.py
@@ -20,9 +20,8 @@
 
 import os
 import sys
-###import psutil
-###import getpass
 import socket
+import nagstacli
 
 # fix/patch for https://bugs.launchpad.net/ubuntu/+source/nagstamon/+bug/732544
 socket.setdefaulttimeout(30)
@@ -30,12 +29,21 @@ socket.setdefaulttimeout(30)
 
 try:
     if __name__ == '__main__':
+        # queue.Queue() needs threading module which might be not such a good idea to be used
+        # because QThread is already in use
+        debug_queue = list()       
+        
         # Initialize global configuration
         from Nagstamon.Config import (conf,
                                       RESOURCES)
 
         from Nagstamon.Helpers import lock_config_folder
 
+        #if there are more args, than the config folder,  nagstaCLI is been executed
+        if len(sys.argv) > 2:
+            nagstacli.executeCli()
+            sys.exit(1)
+        
         # Acquire the lock
         if not lock_config_folder(conf.configdir):
             print('An instance is already running this config ({})'.format(conf.configdir))
@@ -59,7 +67,7 @@ try:
         statuswindow.adjustSize()
 
         if conf.check_for_new_version == True:
-            check_version.check(start_mode = True, parent=statuswindow)
+            check_version.check(start_mode=True, parent=statuswindow)
 
         sys.exit(APP.exec_())
 


### PR DESCRIPTION
 so it is possible to call the downtime for a service/host on a terminal. Could be useful for remote commandline administration tools (e.g. saltstack, docker, etc.). If a host is been
shutdown by a console command, it can be downtimed with a second
command.