### PR TITLE
op5Monitor: Service is in downtime if its host is

### DIFF
--- a/Nagstamon/Servers/op5Monitor.py
+++ b/Nagstamon/Servers/op5Monitor.py
@@ -92,6 +92,7 @@ class Op5MonitorServer(GenericServer):
     api_svc_col.append('host.name')
     api_svc_col.append('host.state')
     api_svc_col.append('host.active_checks_enabled')
+    api_svc_col.append('host.scheduled_downtime_depth')
     api_svc_col.append('is_flapping')
     api_svc_col.append('last_check')
     api_svc_col.append('last_state_change')
@@ -210,7 +211,7 @@ class Op5MonitorServer(GenericServer):
                     n["flapping"] = api['is_flapping']
                     n["notifications_disabled"] = 0 if api['notifications_enabled'] else 1
                     n["passiveonly"] = 0 if api['active_checks_enabled'] else 1
-                    n["scheduled_downtime"] = 1 if api['scheduled_downtime_depth'] else 0
+                    n["scheduled_downtime"] = 1 if api['scheduled_downtime_depth'] or api['host']['scheduled_downtime_depth'] else 0
                     n['attempt'] = "%s/%s" % (str(api['current_attempt']), str(api['max_check_attempts']))
                     n['duration'] = human_duration(api['last_state_change'])
                     n['last_check'] = datetime.fromtimestamp(int(api['last_check'])).strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
A service should be treated as "in scheduled downtime" either if
itself is marked as such, or the service's host is in scheduled downtime.

This fixes #237

Signed-off-by: Carl Helmertz <chelmertz@op5.com>