### PR TITLE
Unhardcode icon path in GNU/Linux laucher

### DIFF
--- a/Nagstamon/resources/nagstamon.desktop
+++ b/Nagstamon/resources/nagstamon.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Nagstamon
 Comment=Nagios status monitor 
-Icon=/usr/share/pixmaps/nagstamon.svg
+Icon=nagstamon
 Exec=nagstamon
 Terminal=false
 Categories=System;Monitor;

--- a/build/debian/nagstamon.desktop
+++ b/build/debian/nagstamon.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Nagstamon
 Comment=Nagios status monitor 
-Icon=/usr/share/pixmaps/nagstamon.svg
+Icon=nagstamon
 Exec=nagstamon
 Terminal=false
 Categories=System;Monitor;

--- a/build/redhat/nagstamon.desktop
+++ b/build/redhat/nagstamon.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Nagstamon
 Comment=Nagios status monitor 
-Icon=/usr/share/nagstamon/Nagstamon/resources/nagstamon.svg
+Icon=nagstamon
 Exec=nagstamon
 Terminal=false
 Categories=System;Monitor;


### PR DESCRIPTION
Since the icon already is installed to ``.../share/pixmaps``, a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path (neither the file type extension) in the launcher. 
The icon will be found anyway.

This facilitates icon theming.
Cf. this [example ``.desktop`` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.