### PR TITLE
Icinga: Fix version detection when setting URLs

### DIFF
--- a/Nagstamon/Servers/Icinga.py
+++ b/Nagstamon/Servers/Icinga.py
@@ -23,6 +23,7 @@ import copy
 import json
 from bs4 import BeautifulSoup
 from collections import OrderedDict
+from distutils.version import LooseVersion
 
 from Nagstamon.Servers.Generic import GenericServer
 from Nagstamon.Objects import (GenericHost, GenericService, Result)
@@ -101,7 +102,7 @@ class IcingaServer(GenericServer):
             if self.version != '':
                 # define CGI URLs for hosts and services depending on JSON-capable server version
                 if self.cgiurl_hosts == self.cgiurl_services == None:
-                    if self.version < '1.7':
+                    if LooseVersion(self.version) < LooseVersion('1.7'):
                         # http://www.nagios-wiki.de/nagios/tips/host-_und_serviceproperties_fuer_status.cgi?s=servicestatustypes
                         # services (unknown, warning or critical?) as dictionary, sorted by hard and soft state type
                         self.cgiurl_services = {'hard': self.monitor_cgi_url + '/status.cgi?host=all&servicestatustypes=253&serviceprops=262144', \


### PR DESCRIPTION
The previous version comparison was flawed, as it only compared strings and thus '1.10' < '1.7' was true. This commit uses the `distutils.version` package to properly compare versions.