### PR TITLE
Fix case sensitive 'apiinfo.version' method name for Zabbix

### DIFF
--- a/Nagstamon/thirdparty/zabbix_api.py
+++ b/Nagstamon/thirdparty/zabbix_api.py
@@ -295,7 +295,7 @@ class ZabbixAPI(object):
 
     def api_version(self, **options):
         self.__checkauth__()
-        obj = self.do_request(self.json_obj('APIInfo.version', options, auth=False))
+        obj = self.do_request(self.json_obj('apiinfo.version', options, auth=False))
         return obj['result']
 
     def __checkauth__(self):


### PR DESCRIPTION
After upgrading Nagstamon from 1.0.1 to 2.0.1, I could not reach our Zabbix server anymore. I had the following error:

```
(<class 'Nagstamon.thirdparty.zabbix_api.ZabbixAPIException'>, ZabbixAPIException('Error -32602: Invalid params., Not authorized while sending {"id": 10, "params": {}, "method": "APIInfo.version", "jsonrpc": "2.0"}', -32602), <traceback object at 0x7f44b803f988>)
```

We didn't change anything, so I tried to call this API method from the command-line regarding the [Zabbix manual](https://www.zabbix.com/documentation/2.2/manual/api/reference/apiinfo/version):

```
$ curl -H "Content-Type: application/json" -X POST https://zabbix/api_jsonrpc.php -d '{"jsonrpc":"2.0","method":"apiinfo.version","params":{},"id":10}'
{"jsonrpc":"2.0","result":"2.2.7","id":1}
```

I then realized that `zabbix_api.py` was not using the strict method name, which seems to be case-sensitive - at least with Zabbix 2.2. It's working fine with this fix. I don't think it will break any other configurations!