### PR TITLE
Really disable InsecureRequestWarning warnings

### DIFF
--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -20,7 +20,7 @@
 import requests
 # disable annoying InsecureRequestWarning warnings
 try:
-    requests.packages.urllib3.disable_warnings()
+    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 except:
     # older requests version might not have the packages submodule
     # for example the one in Ubuntu 14.04


### PR DESCRIPTION
Because of the stubbing and linking and whatnot in requests.packages
performed by requests itself and distribution maintainers, using
disable_warnings without parameters sometimes doesn't work (e.g. on
Debian Stretch). Explicitly passing in the module reference for which to
disable warnings makes it work as intended.

References: #302 and https://bugs.debian.org/861152