### PR TITLE
Increase flicker prevention delay to .5 secs

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -1457,7 +1457,7 @@ class StatusWindow(QWidget):
                self.is_shown is True and\
                self.moving is True:
                 # only hide if shown at least a fraction of a second
-                if self.is_shown_timestamp + 0.1 < time.time():
+                if self.is_shown_timestamp + 0.5 < time.time():
                     if conf.statusbar_floating:
                         self.statusbar.show()
                         self.statusbar.adjustSize()


### PR DESCRIPTION
Hi! :) #184 is back.

The problem happens in Linux/KDE when the window height is bigger than the
screen height. As soon as the window is shown, it gets on top of the tray bar
and an "enterEvent fires". Moments later (sometimes even .2 secs later), the
tray bar gets back to top, the window goes behind it, and a "leaveEvent" is
fired.

A .5 sec timeout seems to be a reasonable timeout also in different situations.