### PR TITLE
#402 Nagstamon crash with Centreon

### DIFF
--- a/Nagstamon/Servers/Centreon.py
+++ b/Nagstamon/Servers/Centreon.py
@@ -24,8 +24,6 @@ import socket
 import sys
 import re
 import copy
-# import time
-# import datetime
 
 from Nagstamon.Objects import *
 from Nagstamon.Servers.Generic import GenericServer
@@ -64,6 +62,7 @@ class CentreonServer(GenericServer):
         dummy init_config, called at thread start, not really needed here, just omit extra properties
         '''
         # set URLs here already
+        self.init_HTTP()
         self._define_url()
 
     def init_HTTP(self):
@@ -137,6 +136,11 @@ class CentreonServer(GenericServer):
             else:
                 if conf.debug_mode is True:
                     self.Debug(server=self.get_name(), debug='Error getting the home page : ' + error_versioncheck)
+
+            if self.first_login:
+                self.SID = self._get_sid().result
+                self.first_login = False
+
             del result_versioncheck, raw_versioncheck, error_versioncheck
 
     def reset_HTTP(self):


### PR DESCRIPTION
Hello,
I have this issue with Centreon 2.8.9, apparently init_HTTP is never called because of that XML_PATH is no created. I solved it adding init_HTTP in init_config, and using _get_sid just after centreon_version initialization.
I tested it with python 3.6 in Ubuntu, all work fine.

