### PR TITLE
feature: quoting variables in custom actions

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -41,6 +41,8 @@ import base64
 import datetime
 import traceback
 
+from urllib.parse import quote
+
 from collections import OrderedDict
 from copy import deepcopy
 
@@ -4048,6 +4050,9 @@ class TreeView(QTreeView):
 
                 # mapping mapping
                 for i in mapping:
+                    # mapping with urllib.quote
+                    string = string.replace("$"+i+"$", quote(mapping[i]))
+                    # normal mapping
                     string = string.replace(i, mapping[i])
 
                 # see what action to take


### PR DESCRIPTION
added feature to quote variables with urllib.quote for custom actions. To use this, add 2nd "$" at the beginning and end of the variable. Example: $$STATUS-INFO$$

#374 