### PR TITLE
Fix host duration counter for Opsview/Nagios

### DIFF
--- a/Nagstamon/Helpers.py
+++ b/Nagstamon/Helpers.py
@@ -132,17 +132,18 @@ def HumanReadableDurationFromSeconds(seconds):
         if timedelta.find("day") == -1:
             hms = timedelta.split(":")
             if len(hms) == 1:
-                return "%02ds" % (hms[0])
+                return "%02sh" % (hms[0])
             elif len(hms) == 2:
-                return "%02dm %02ds" % (hms[0], hms[1])
+                return "%02sm %02ss" % (hms[1], hms[2])
             else:
-                return "%sh %02dm %02ds" % (hms[0], hms[1], hms[2])
+                return "%sh %02sm %02ss" % (hms[0], hms[1], hms[2])
         else:
             # waste is waste - does anyone need it?
             days, waste, hms = str(timedelta).split(" ")
             hms = hms.split(":")
-            return "%sd %sh %02dm %02ds" % (days, hms[0], hms[1], hms[2])
+            return "%sd %sh %02sm %02ss" % (days, hms[0], hms[1], hms[2])
     except Exception:
+        traceback.print_exc(file=sys.stdout)
         # in case of any error return seconds we got
         return seconds
 


### PR DESCRIPTION
After fixing it I can confirm that Nagstamon is now countering the host status duration's values just fine for both (Nagios and Opsview).

P.S. Leaving screenshots for you.

[Screenshot 1](https://www.dropbox.com/s/oq3h27n9g7ajwcf/duration_counter.png?dl=0
)
[Screenshot 2](https://www.dropbox.com/s/zsm5usaz1w54n7u/fix_counter.png?dl=0)