### PR TITLE
Add token authentication via password field for Uchiwa/Sensu

### DIFF
--- a/Nagstamon/thirdparty/sensu_api.py
+++ b/Nagstamon/thirdparty/sensu_api.py
@@ -45,6 +45,9 @@ class SensuAPI(object):
 
         if username and password:
             self.auth = HTTPBasicAuth(username, password)
+        elif password and not username:
+            self._header['Authorization'] = 'token {}'.format(password)
+            self.auth = None
         else:
             self.auth = None
 


### PR DESCRIPTION
Uchiwa is the frontend/dashboard for Sensu's community edition. It requires a token for authentication (set up in Uchiwa's config). This allows a user to store their token in the password field, leaving the username field blank, and have access all Sensu servers configured in Uchiwa. 

I can make further changes to this file so it respects the options in the Edit server... window (e.g., Ignore SSL/TLS certificate) if there's any desire for it.