### PR TITLE
Add the dc from an event for recheck

### DIFF
--- a/Nagstamon/Servers/Sensu.py
+++ b/Nagstamon/Servers/Sensu.py
@@ -112,6 +112,7 @@ class SensuServer(GenericServer):
             for event in events:
                 event_check = event['check']
                 event_client = event['client']
+
                 new_service = GenericService()
                 new_service.event_id = event['id']
                 new_service.host = event_client['name']

--- a/Nagstamon/thirdparty/sensu_api.py
+++ b/Nagstamon/thirdparty/sensu_api.py
@@ -188,7 +188,7 @@ class SensuAPI(object):
         data = self._request('GET', '/checks/{}'.format(check))
         return data.json()
 
-    def post_check_request(self, check, subscribers):
+    def post_check_request(self, check, subscribers, dc=None):
         """
         Issues a check execution request.
         """
@@ -196,7 +196,9 @@ class SensuAPI(object):
             'check': check,
             'subscribers': [subscribers]
         }
-        self._request('POST', '/request', data=json.dumps(data))
+        if dc is not None:
+            data['dc'] = dc
+        self._request('POST', '/request', json=data)
         return True
 
     """


### PR DESCRIPTION
This fixes #497. Please let me know if there's a better way to access an attribute of a `GenericHost` than what I used: `self.hosts[info_dict['host']].site`. I didn't see how to add it to info_dict (and QUI kind of scares me).