### PR TITLE
Update Multisite.py

### DIFF
--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -200,7 +200,7 @@ class MultisiteServer(GenericServer):
         # get cookie from login page via url retrieving as with other urls
         try:
             # login and get cookie
-            self.FetchURL(self.monitor_url + '/login.py', cgi_data=login_data, multipart=True)
+            self.FetchURL(self.monitor_url + 'login.py', cgi_data=login_data, multipart=True)
         except:
             import traceback
             traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
Fixed issues with Check_MK 1.6 authentication. Check_MK 1.6 throws a 404 when a double slash is in the URL.

Referencing issue #586

(I'm sorry, this is my first ever pull request. If I did anything wrong please let me know. It's really just removing one character.)