### PR TITLE
monitos4x: Added host and services links (new monitos routes)

### DIFF
--- a/Nagstamon/Servers/Monitos4x.py
+++ b/Nagstamon/Servers/Monitos4x.py
@@ -92,8 +92,8 @@ class Monitos4xServer(GenericServer):
     }
     BROWSER_URLS = {
         'monitor': '$MONITOR$',
-        'hosts': '$MONITOR$',
-        'services': '$MONITOR$',
+        'hosts': '$MONITOR$/#/host-problems',
+        'services': '$MONITOR$/#/service-problems',
         'history': '$MONITOR$/#/alert/ticker'
     }
 


### PR DESCRIPTION
Added Browser links for new implemented monitos routes:

Hosts:
- https://monitos/#/host-problems

Services:
- https://monitos/#/service-problems