### PR TITLE
monitos 4.4+ no longer experimental: A lot tested with version 3.3-20…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Nagstamon
 =========
 
-Nagstamon is a status monitor for the desktop. It connects to multiple Nagios, Icinga, Opsview, Centreon, Op5 Monitor/Ninja, Check_MK Multisite and Thruk monitoring servers. Experimental support is provided for Zabbix, Zenoss and Livestatus monitors. It resides in systray, as a floating statusbar or fullscreen at the desktop showing a brief summary of critical, warning, unknown, unreachable and down hosts and services. It pops up a detailed status overview when being touched by the mouse pointer. Connections to displayed hosts and services are easily established by context menu via SSH, RDP, VNC or any self defined actions. Users can be notified by sound. Hosts and services can be filtered by category and regular expressions.
+Nagstamon is a status monitor for the desktop. It connects to multiple Nagios, Icinga, Opsview, Centreon, Op5 Monitor/Ninja, Check_MK Multisite, Thruk and monitos monitoring servers. Experimental support is provided for Zabbix, Zenoss and Livestatus monitors. It resides in systray, as a floating statusbar or fullscreen at the desktop showing a brief summary of critical, warning, unknown, unreachable and down hosts and services. It pops up a detailed status overview when being touched by the mouse pointer. Connections to displayed hosts and services are easily established by context menu via SSH, RDP, VNC or any self defined actions. Users can be notified by sound. Hosts and services can be filtered by category and regular expressions.
 
 It is inspired by Nagios Checker for Firefox – just without an open Firefox window all the time to monitor the network.
 
@@ -19,11 +19,11 @@ Successfully tested monitors include:
  - Op5 Monitor 7+
  - Check_MK/Multisite 1.1.10+
  - Thruk 1.5.0+
+ - monitos 4.4+
  - Livestatus – experimental
  - Zabbix 2.2+ – experimental
  - Zenoss – experimental
  - monitos 3 - experimental
- - monitos 4.3.1+ - experimental
  - SNAG-View3 - experimental
 
 See https://nagstamon.ifw-dresden.de for further information.


### PR DESCRIPTION
monitos4 no longer experimental: A lot tested with version 3.3-20191010 (Win10 & macOS 10.14)