### PR TITLE
Momiji patch 1

### DIFF
--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -84,9 +84,12 @@ class ZabbixServer(GenericServer):
 
     def _login(self):
         try:
-            self.zapi = ZabbixAPI(server=self.monitor_url, path="", log_level=self.log_level,
-                                  validate_certs=self.validate_certs)
-            self.zapi.login(self.username, self.password)
+            # create ZabbixAPI if not yet created
+            if self.zapi is None:
+                self.zapi = ZabbixAPI(server=self.monitor_url, path="", log_level=self.log_level, validate_certs=self.validate_certs)
+            # login if not yet logged in, or if login was refused previously
+            if not self.zapi.logged_in():
+                self.zapi.login(self.username, self.password)
         except ZabbixAPIException:
             result, error = self.Error(sys.exc_info())
             return Result(result=result, error=error)
@@ -112,8 +115,7 @@ class ZabbixServer(GenericServer):
         nagitems = {"services": [], "hosts": []}
 
         # Create URLs for the configured filters
-        if self.zapi is None:
-            self._login()
+        self._login()
 
         try:
             # =========================================
@@ -458,8 +460,7 @@ class ZabbixServer(GenericServer):
         for s in all_services:
             triggerids.append(s)
 
-        if self.zapi is None:
-            self._login()
+        self._login()
 
         for triggerid in triggerids:
             events = []

--- a/Nagstamon/thirdparty/zabbix_api.py
+++ b/Nagstamon/thirdparty/zabbix_api.py
@@ -276,7 +276,7 @@ class ZabbixAPI(object):
             jobj = json.loads(reads.decode('utf-8'))
         except ValueError as msg:
             print ("unable to decode. returned string: %s" % reads)
-            sys.exit(-1)
+            raise ZabbixAPIException("Unable to decode answer")
         self.debug(logging.DEBUG, "Response Body: " + str(jobj))
 
         self.id += 1


### PR DESCRIPTION
Hello,

This PR to change the zabbix login logic.

It appears that when zabbix server is not yet available, which happens if program starts before network  is connected (when I'm working with VPN for example), then login fails and is never called later, unless restarting program or doing a fake server update.

This patch allows to retry login until it succeeds, and fixes the "unable to decode" error to return an exception instead of exiting ; this happens during the very start of the VPN connection, due to stupid enterprise hidden reverse proxy...

Do not hesitate if you need more information.

Regards.