### PR TITLE
Prometheus: support non-kubernetes alerts and a bit of cleanup

### DIFF
--- a/Nagstamon/Servers/Prometheus.py
+++ b/Nagstamon/Servers/Prometheus.py
@@ -45,7 +45,9 @@
 #         Inital version
 #
 import sys
-import urllib.request, urllib.parse, urllib.error
+import urllib.request
+import urllib.parse
+import urllib.error
 import copy
 import pprint
 import json
@@ -63,32 +65,32 @@ from Nagstamon.Servers.Generic import GenericServer
 from Nagstamon.Helpers import (HumanReadableDurationFromSeconds,
                                webbrowser_open)
 
+
 class PrometheusService(GenericService):
     """
-	    add Prometheus specific service property to generic service class
+    add Prometheus specific service property to generic service class
     """
     service_object_id = ""
 
 
 class PrometheusServer(GenericServer):
     """
-       special treatment for Prometheus API
+    special treatment for Prometheus API
     """
     TYPE = 'Prometheus'
 
     # Prometheus actions are limited to visiting the monitor for now
     MENU_ACTIONS = ['Monitor']
-    BROWSER_URLS= {
+    BROWSER_URLS = {
         'monitor':  '$MONITOR$/alerts',
         'hosts':    '$MONITOR$/targets',
         'services': '$MONITOR$/service-discovery',
         'history':  '$MONITOR$/graph'
     }
 
-
     def init_HTTP(self):
         """
-            things to do if HTTP is not initialized
+        things to do if HTTP is not initialized
         """
         GenericServer.init_HTTP(self)
 
@@ -96,29 +98,27 @@ class PrometheusServer(GenericServer):
         self.session.headers.update({'Accept': 'application/json',
                                      'Content-Type': 'application/json'})
 
-
     def init_config(self):
         """
-	        dummy init_config, called at thread start
+        dummy init_config, called at thread start
         """
         pass
 
-
     def get_start_end(self, host):
         """
-            Set a default of starttime of "now" and endtime is "now + 24 hours"
+        Set a default of starttime of "now" and endtime is "now + 24 hours"
         directly from web interface
         """
         start = datetime.now()
         end = datetime.now() + timedelta(hours=24)
 
-        return str(start.strftime("%Y-%m-%d %H:%M:%S")), str(end.strftime("%Y-%m-%d %H:%M:%S"))
-
+        return (str(start.strftime("%Y-%m-%d %H:%M:%S")),
+                str(end.strftime("%Y-%m-%d %H:%M:%S")))
 
     def _get_duration(self, timestring):
         """
-            calculates the duration (delta) from Prometheus' activeAt (ISO8601 format) until now
-            an returns a human friendly string
+        calculates the duration (delta) from Prometheus' activeAt (ISO8601
+        format) until now an returns a human friendly string
         """
         time_object = dateutil.parser.parse(timestring)
         duration = datetime.now(timezone.utc) - time_object
@@ -134,71 +134,82 @@ class PrometheusServer(GenericServer):
         else:
             return "%02ds" % (s)
 
-
-    def _set_downtime(self, host, service, author, comment, fixed, start_time, end_time, hours, minutes):
+    def _set_downtime(self, host, service, author, comment, fixed, start_time,
+                      end_time, hours, minutes):
         """
-	        to be implemented in a future release
+        to be implemented in a future release
         """
         pass
 
-
     def _get_status(self):
         """
-	        Get status from Prometheus Server
+        Get status from Prometheus Server
         """
         # get all alerts from the API server
         try:
-            result = self.FetchURL(self.monitor_url + "/api/v1/alerts", giveback="raw")
-            data, error, status_code = json.loads(result.result), result.error, result.status_code
+            result = self.FetchURL(self.monitor_url + "/api/v1/alerts",
+                                   giveback="raw")
+            data = json.loads(result.result)
+            error = result.error
+            status_code = result.status_code
 
             # check if any error occured
             errors_occured = self.check_for_error(data, error, status_code)
-            # if there are errors return them
-            if errors_occured != False:
+            if errors_occured is not False:
                 return(errors_occured)
 
             if conf.debug_mode:
-                self.Debug(server=self.get_name(), debug="Fetched JSON: " + pprint.pformat(data))
+                self.Debug(server=self.get_name(),
+                           debug="Fetched JSON: " + pprint.pformat(data))
 
             for alert in data["data"]["alerts"]:
                 if conf.debug_mode:
-                    self.Debug(server=self.get_name(), debug="Processing Alert: " + pprint.pformat(alert))
+                    self.Debug(
+                        server=self.get_name(),
+                        debug="Processing Alert: " + pprint.pformat(alert)
+                    )
 
-                if alert["labels"]["severity"] != "none":
-                    if "pod_name" in alert["labels"]:
-                        hostname = alert["labels"]["pod_name"]
-                    elif "namespace" in alert["labels"]:
-                        hostname = alert["labels"]["namespace"]
-                    else:
-                        hostname = "unknown"
+                labels = alert.get("labels", {})
 
+                # skip alerts with none severity
+                severity = labels.get("severity", "UNKNOWN").upper()
+                if severity == "NONE":
+                    continue
+
+                if "pod_name" in labels:
+                    hostname = labels["pod_name"]
+                elif "namespace" in labels:
+                    hostname = labels["namespace"]
+                elif "instance" in labels:
+                    hostname = labels["instance"]
+                else:
+                    hostname = "unknown"
+                servicename = labels.get("alertname", "unknown")
+
+                service = PrometheusService()
+                service.host = str(hostname)
+                service.name = servicename
+                service.server = self.name
+                service.status = severity
+                service.last_check = "n/a"
+                service.attempt = alert.get("state", "firirng")
+                service.duration = str(self._get_duration(alert["activeAt"]))
+
+                annotations = alert.get("annotations", {})
+                status_information = ""
+                if "message" in annotations:
+                    status_information = annotations["message"]
+                if "summary" in annotations:
+                    status_information = annotations["summary"]
+                if "descriptions" in annotations:
+                    status_information = annotations["description"]
+                service.status_information = status_information
+
+                if hostname not in self.new_hosts:
                     self.new_hosts[hostname] = GenericHost()
                     self.new_hosts[hostname].name = str(hostname)
                     self.new_hosts[hostname].server = self.name
-
-                    if "alertname" in alert["labels"]:
-                        servicename = alert["labels"]["alertname"]
-                    else:
-                        servicename = "unknown"
-
-                    self.new_hosts[hostname].services[servicename] = PrometheusService()
-                    self.new_hosts[hostname].services[servicename].host = str(hostname)
-                    self.new_hosts[hostname].services[servicename].name = servicename
-                    self.new_hosts[hostname].services[servicename].server = self.name
-
-                    if ((alert["labels"]["severity"].upper() == "CRITICAL") or (alert["labels"]["severity"].upper() == "WARNING")):
-                        self.new_hosts[hostname].services[servicename].status = alert["labels"]["severity"].upper()
-                    else:
-                        self.new_hosts[hostname].services[servicename].status = "UNKNOWN"
-
-                    self.new_hosts[hostname].services[servicename].last_check = "n/a"
-                    self.new_hosts[hostname].services[servicename].attempt = alert["state"].upper()
-                    self.new_hosts[hostname].services[servicename].duration = str(self._get_duration(alert["activeAt"]))
-
-                    try:
-                        self.new_hosts[hostname].services[servicename].status_information = alert["annotations"]["message"].replace("\n", " ")
-                    except KeyError:
-                        self.new_hosts[hostname].services[servicename].status_information = ""
+                self.new_hosts[hostname].services[servicename] = service
 
         except:
             # set checking flag back to False
@@ -206,32 +217,20 @@ class PrometheusServer(GenericServer):
             result, error = self.Error(sys.exc_info())
             return Result(result=result, error=error)
 
-        #dummy return in case all is OK
+        # dummy return in case all is OK
         return Result()
 
-
     def open_monitor_webpage(self, host, service):
+        """
+        open monitor from tablewidget context menu
+        """
         webbrowser_open('%s' % (self.monitor_url))
 
     def open_monitor(self, host, service=''):
-        '''
-            open monitor from tablewidget context menu
-        '''
-
-        if conf.debug_mode:
-            self.Debug(server=self.get_name(), host=host, service=service,
-                       debug='Open host/service monitor web page ' +
-                             self.monitor_url + '/graph?g0.range_input=1h&g0.expr=' +
-                             urllib.parse.quote('ALERTS{alertname="' + service + '",pod_name="' + host + '"}', safe='') + '&g0.tab=1')
-        webbrowser_open(self.monitor_url + '/graph?g0.range_input=1h&g0.expr=' +
-                        urllib.parse.quote('ALERTS{alertname="' + service + '",pod_name="' + host + '"}', safe='') + '&g0.tab=1')
-
-    def open_monitor_webpage(self):
-        '''
-            open monitor from systray/toparea context menu
-        '''
-
-        if conf.debug_mode:
-            self.Debug(server=self.get_name(),
-                       debug='Open monitor web page ' + self.monitor_url)
-        webbrowser_open(self.monitor_url)
+        """
+        open monitor for alert
+        """
+        url = '%s/graph?g0.range_input=1h&g0.expr=%s'
+        url = url % (self.monitor_url,
+                     urllib.parse.quote('ALERTS{alertname="%s"}' % service))
+        webbrowser_open(url)


### PR DESCRIPTION
This adds support for alerts that have neither `pod_name` nor `namespace` defined.

Also removes the hardcoded `pod_name` in the browser url, since this breaks all alerts that aren't pod related.

Also some changes to make the linter happy and the code easier to read.