### PR TITLE
Detect OS release case-insensitive

### DIFF
--- a/Nagstamon/Helpers.py
+++ b/Nagstamon/Helpers.py
@@ -454,11 +454,13 @@ def get_distro():
             for property in os_release_file.read_text().splitlines():
                 key, value = property.split('=', 1)
                 os_release_dict[key] = value.strip('"').strip("'")
-            return (os_release_dict.get('ID'), os_release_dict.get('VERSION_ID'), os_release_dict.get('NAME'))
+            return (os_release_dict.get('ID').lower(),
+                    os_release_dict.get('VERSION_ID').lower(),
+                    os_release_dict.get('NAME').lower())
         else:
             return False
     else:
-        return platform.dist()
+        return platform.dist().lower()
 
 
     # depending on column different functions have to be used

--- a/build/build.py
+++ b/build/build.py
@@ -212,8 +212,8 @@ def rpmmain():
 
 DISTS = {
     'debian': debmain,
-    'Ubuntu': debmain,
-    'LinuxMint': debmain,
+    'ubuntu': debmain,
+    'linuxmint': debmain,
     'fedora': rpmmain
 }
 
@@ -223,7 +223,6 @@ if __name__ == '__main__':
     elif platform.system() == 'Darwin':
         macmain()
     else:
-        #dist = platform.dist()[0]
         dist = get_distro()[0]
         if dist in DISTS:
             DISTS[dist]()


### PR DESCRIPTION
On some ubuntu systems, os_release_dict returns `ubuntu` instead of
`Ubuntu`, so we compare case-insensitive.