### PR TITLE
Fix issue #655 - by returning 'unknown' as VERSION_ID if value missing

### DIFF
--- a/Nagstamon/Helpers.py
+++ b/Nagstamon/Helpers.py
@@ -455,7 +455,7 @@ def get_distro():
                 key, value = property.split('=', 1)
                 os_release_dict[key] = value.strip('"').strip("'")
             return (os_release_dict.get('ID').lower(),
-                    os_release_dict.get('VERSION_ID').lower(),
+                    os_release_dict.get('VERSION_ID', 'unknown').lower(),
                     os_release_dict.get('NAME').lower())
         else:
             return False


### PR DESCRIPTION
Just added code to set VERSION_ID to a default value if it doesn't exist, fixes using python 3.7+ on Gentoo where they don't set a VERSION_ID in /etc/os-release (related to https://bugs.gentoo.org/718424). Possibly affects more than Gentoo as https://www.freedesktop.org/software/systemd/man/os-release.html says VERSION_ID is optional.