### PR TITLE
fix AttributeError for Qt.AA_EnableHighDpiScaling with Qt 5.5

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -114,7 +114,10 @@ if not OS in OS_NON_LINUX:
         DBUS_AVAILABLE = False
 
 # enable HighDPI-awareness to avoid https://github.com/HenriWahl/Nagstamon/issues/618
-QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+try:
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+except AttributeError:
+    pass
 QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 # global application instance
 APP = QApplication(sys.argv)


### PR DESCRIPTION
The Qt.AA_EnableHighDpiScaling property was introduced with Qt 5.6.

Without the fix I'm getting this error message when starting Nagstamon on a Linux system with Qt 5.5:

```
Traceback (most recent call last):
  File "/usr/bin/nagstamon", line 45, in <module>
    from Nagstamon.QUI import (APP,
  File "/usr/lib/python3/dist-packages/Nagstamon/QUI/__init__.py", line 117, in <module>
    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
AttributeError: type object 'Qt' has no attribute 'AA_EnableHighDpiScaling'
```

The line which causes the exception was added in https://github.com/HenriWahl/Nagstamon/issues/618. I suppose it's no big problem if HighDPI doesn't work on such old systems, though.