### PR TITLE
Allow to install on nixos

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -1064,3 +1064,6 @@ except Exception as err:
         if os.path.exists(path):
             RESOURCES = path
             break
+    else:
+        from pathlib import Path
+        RESOURCES = str(Path(__file__).parent.absolute().joinpath('resources'))

--- a/Nagstamon/Helpers.py
+++ b/Nagstamon/Helpers.py
@@ -458,7 +458,7 @@ def get_distro():
                     os_release_dict.get('VERSION_ID', 'unknown').lower(),
                     os_release_dict.get('NAME').lower())
         else:
-            return False
+            return '', '', ''
     else:
         # fix for non-working build on Debian<10
         dist_name, dist_version, dist_id = platform.dist()


### PR DESCRIPTION
This fixes `get_distro()` and the path resolution for `RESOURCES` on nixos and maybe other platforms.

Since these are just fallback options this should not affect any currently working systems.
