### PR TITLE
bail out if cacert cannot be found on Mac to prevent runtime errors

### DIFF
--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -200,6 +200,8 @@ class GenericServer(object):
                 # ...and its content
                 with open(self.cacert_path, mode='rb') as file:
                     self.cacert_content = file.read()
+            else:
+                raise AssertionError("Cannot find cacert.pem. SSL Connections will not work.")
 
         # Special FX
         # Centreon


### PR DESCRIPTION
Currently, Nagstamon will fail silently when run from the source folder. This will at least make it explicit. Can you add the following to the install or dev install instructions on your website?

```
mkdir certifi
cd certifi
wget https://curl.haxx.se/ca/cacert.pem
```

Afterwards, Nagstamon works fine on a development system.