### PR TITLE
fixing acknowleded services filter in zabbix

### DIFF
--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -1088,7 +1088,8 @@ class GenericServer(object):
                             self.Debug(server=self.get_name(),
                                        debug='Filter: SOFT STATE ' + str(host.name) + ';' + str(service.name))
                         service.visible = False
-                else:
+                # fix for https://github.com/HenriWahl/Nagstamon/issues/654
+                elif self.TYPE.startswith("Zabbix"):
                     if len(service.attempt) < 3:
                         service.visible = True
                     elif len(service.attempt) == 3:


### PR DESCRIPTION
Fixes #654 

Skipping block of code that sets
`service.visible = True`
on all services with attempt field (populated by application name from zabbix item), when serwer type meches Zabbix.