### PR TITLE
Add SensuGo

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5740,8 +5740,8 @@ class Dialog_Server(Dialog):
         # these widgets are shown or hidden depending on server type properties
         # the servers listed at each widget do need them
         self.VOLATILE_WIDGETS = {
-            self.ui.label_monitor_cgi_url: ['Nagios', 'Icinga', 'Thruk', 'Sensu'],
-            self.ui.input_lineedit_monitor_cgi_url: ['Nagios', 'Icinga', 'Thruk', 'Sensu'],
+            self.ui.label_monitor_cgi_url: ['Nagios', 'Icinga', 'Thruk', 'Sensu', 'SensuGo'],
+            self.ui.input_lineedit_monitor_cgi_url: ['Nagios', 'Icinga', 'Thruk', 'Sensu', 'SensuGo'],
             self.ui.input_checkbox_use_autologin: ['Centreon', 'monitos4x', 'Thruk'],
             self.ui.input_lineedit_autologin_key: ['Centreon', 'monitos4x', 'Thruk'],
             self.ui.label_autologin_key: ['Centreon', 'monitos4x', 'Thruk'],

--- a/Nagstamon/Servers/SensuGo.py
+++ b/Nagstamon/Servers/SensuGo.py
@@ -1,0 +1,111 @@
+import sys
+import traceback
+from Nagstamon.Servers.Generic import GenericServer
+from Nagstamon.Objects import (GenericHost, GenericService, Result)
+from Nagstamon.Config import conf
+from Nagstamon.thirdparty.sensugo_api import SensuGoAPI, SensuGoAPIException
+from Nagstamon.Helpers import HumanReadableDurationFromTimestamp
+from time import time
+from datetime import datetime
+
+NAMESPACE_SEPARATOR = ' ||| '
+class SensuGoServer(GenericServer):
+    TYPE = 'SensuGo'
+    MENU_ACTIONS = ['Acknowledge']
+
+    _authentication = 'basic'
+    _api_url = ''
+    _sensugo_api = None
+
+    def __init__(self, **kwds):
+        GenericServer.__init__(self, **kwds)
+        self._api_url = conf.servers[self.get_name()].monitor_cgi_url
+        self.reset_HTTP()
+
+    def init_HTTP(self):
+        GenericServer.init_HTTP(self)
+        self._setup_sensugo_api()
+
+    def reset_HTTP(self):
+        self._sensugo_api = SensuGoAPI(self._api_url)
+
+    def _setup_sensugo_api(self):
+        if not self._sensugo_api.has_acquired_token():
+            if self.custom_cert_use:
+                verify = self.custom_cert_ca_file
+            else:
+                verify = not self.ignore_cert
+
+            try:
+                self._sensugo_api.auth(self.username, self.password, verify)
+            except Exception:
+                self.Error(sys.exc_info())
+
+    def _get_status(self):
+        try:
+            response_code, events = self._sensugo_api.get_all_events()
+            self._create_services(events)
+        except Exception:
+            result, error = self.Error(sys.exc_info())
+            print(traceback.format_exc())
+            return Result(result=result, error=error)
+        return Result()
+
+    def _create_services(self, events):
+        for event in events:
+            service = self._parse_event_to_service(event)
+            self._insert_service_to_hosts(service)
+
+    def _parse_event_to_service(self, event):
+        service = GenericService()
+        namespace_host = event['entity']['metadata']['namespace'] + NAMESPACE_SEPARATOR + event['entity']['metadata']['name']
+        service.hostid = namespace_host
+        service.host = namespace_host
+        service.name = event['check']['metadata']['name']
+        service.status = SensuGoAPI.parse_check_status(event['check']['status'])
+        service.last_check = datetime.fromtimestamp(int(event['timestamp'])).strftime('%Y-%m-%d %H:%M:%S')
+        service.duration = self._duration_since(event['check']['last_ok'])
+        service.status_information = event['check']['output']
+        service.acknowledged = event['check']['is_silenced']
+        service.notifications_disabled = event['check']['is_silenced']
+        service.attempt = str(event['check']['occurrences']) + '/1'
+        service.passiveonly = event['check']['publish']
+        service.flapping = False
+        service.scheduled_downtime = False
+        return service
+
+    def _insert_service_to_hosts(self, service: GenericService):
+        service_host = service.get_host_name()
+        if service_host not in self.new_hosts:
+            self.new_hosts[service_host] = GenericHost()
+            self.new_hosts[service_host].name = service_host
+            self.new_hosts[service_host].site = service.site
+
+        self.new_hosts[service_host].services[service.name] = service
+
+    def _duration_since(self, timestamp):
+        if (timestamp == 0) or (timestamp > time()):
+            duration_text = 'n/a'
+        else:
+            duration_text = HumanReadableDurationFromTimestamp(timestamp)
+        return duration_text
+
+    def set_acknowledge(self, info_dict):
+        namespace = self._extract_namespace(info_dict['host'])
+
+        silenece_args = {
+            'metadata': {
+                'name': info_dict['service'],
+                'namespace': namespace
+            },
+            'expire': -1,
+            'expire_on_resolve': True,
+            'creator': info_dict['author'],
+            'reason': info_dict['comment'],
+            'check': info_dict['service']
+        }
+        self._sensugo_api.create_or_update_silence(silenece_args)
+
+    def _extract_namespace(self, host_column: str):
+        return host_column.split(NAMESPACE_SEPARATOR)[0]
+

--- a/Nagstamon/Servers/__init__.py
+++ b/Nagstamon/Servers/__init__.py
@@ -49,6 +49,7 @@ from Nagstamon.Servers.Monitos3 import Monitos3Server
 from Nagstamon.Servers.Monitos4x import Monitos4xServer
 from Nagstamon.Servers.SnagView3 import SnagViewServer
 from Nagstamon.Servers.Sensu import SensuServer
+from Nagstamon.Servers.SensuGo import SensuGoServer
 from Nagstamon.Servers.Prometheus import PrometheusServer
 from Nagstamon.Servers.Alertmanager import AlertmanagerServer
 
@@ -217,8 +218,8 @@ def create_server(server=None):
 # moved registration process here because of circular dependencies
 servers_list = [CentreonServer, IcingaServer, IcingaWeb2Server, MultisiteServer, NagiosServer,
                 Op5MonitorServer, OpsviewServer, ThrukServer, ZabbixServer, SensuServer,
-                LivestatusServer, ZenossServer, Monitos3Server, Monitos4xServer, SnagViewServer,
-                PrometheusServer, AlertmanagerServer, ZabbixProblemBasedServer]
+                SensuGoServer, LivestatusServer, ZenossServer, Monitos3Server, Monitos4xServer,
+                SnagViewServer, PrometheusServer, AlertmanagerServer, ZabbixProblemBasedServer]
 # we use these servers conditionally if modules are available only
 if icinga2api_is_available is True:
     servers_list.append(Icinga2APIServer)

--- a/Nagstamon/thirdparty/sensugo_api.py
+++ b/Nagstamon/thirdparty/sensugo_api.py
@@ -1,0 +1,75 @@
+import json
+import logging
+import requests
+from requests.auth import HTTPBasicAuth
+
+logger = logging.getLogger(__name__)
+
+class SensuGoAPIException(Exception):
+    pass
+
+class SensuGoAPI(object):
+    _base_api_url = ''
+    _refresh_token = ''
+    _session = None
+
+    GOOD_RESPONSE_CODES = (200, 201, 202, 204)
+
+    SEVERITY_CHECK_STATUS = {
+        0: 'OK',
+        1: 'WARNING',
+        2: 'CRITICAL',
+        3: 'UNKNOWN'
+    }
+
+    def __init__(self, base_api_url):
+        self._base_api_url = base_api_url
+        self._session = requests.Session()
+
+    def auth(self, username, password, verify):
+        response = self._session.get(
+            f'{self._base_api_url}/auth',
+            verify=verify,
+            auth=HTTPBasicAuth(username, password))
+
+        self._update_local_tokens(response)
+
+    def _refresh_access_token(self):
+        response = self._session.post(
+            f'{self._base_api_url}/auth/token',
+            json={'refresh_token': self._refresh_token})
+
+        self._update_local_tokens(response)
+
+    def _update_local_tokens(self, response):
+        if response.status_code in SensuGoAPI.GOOD_RESPONSE_CODES:
+            access_token = response.json()['access_token']
+            self._session.headers.update({
+                'Authorization': f'Bearer {access_token}'})
+
+            self._refresh_token = response.json()['refresh_token']
+        else:
+            logger.error(f'Response code: {response.status_code} {response.text}')
+            raise SensuGoAPIException('API returned bad request')
+
+    def get_all_events(self):
+        self._refresh_access_token()
+        response = self._session.get(f'{self._base_api_url}/api/core/v2/events')
+        return (response.status_code, response.json())
+
+    def has_acquired_token(self):
+        return self._refresh_token != ''
+
+    @staticmethod
+    def parse_check_status(status_code):
+        status = SensuGoAPI.SEVERITY_CHECK_STATUS[3]
+        if status_code in SensuGoAPI.SEVERITY_CHECK_STATUS:
+            status = SensuGoAPI.SEVERITY_CHECK_STATUS[status_code]
+        return status
+
+    def create_or_update_silence(self, kwargs):
+        namespace = kwargs['metadata']['namespace']
+        check = kwargs['metadata']['name']
+        silence_api = f'/api/core/v2/namespaces/{namespace}/silenced/{check}'
+        self._session.put(self._base_api_url + silence_api, json=kwargs)
+


### PR DESCRIPTION
Enable Nagstamon to work with SensuGo
**Features**
- Register SensuGo server
- Display SensuGo check results in status window
- Acknowledge(expire on resolve), acknowledge comment
- Filtering acknowledged service, and disable check

Room to improve
SensuGo has namespace concept which Nagstamon does not have a column for it. As of this commit, Namespace and Host display under host column in format: &lt;Namespace&gt; ||| &lt;Host&gt;