### PR TITLE
Fix build with Python 3.8 and onward on FreeBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ OS = platform.system()
 if OS not in ['Windows', 'Darwin']:
     if OS == 'Linux':
         DIST, DIST_VERSION, DIST_NAME = get_distro()
+    # platform.dist() returns "('', '', '')" on FreeBSD
+    elif OS == 'FreeBSD':
+        DIST, DIST_VERSION, DIST_NAME = ('', '', '')
     else:
         DIST, DIST_VERSION, DIST_NAME = platform.dist()
     NAME = NAME.lower()


### PR DESCRIPTION
Hello @HenriWahl, I've received [this](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254502) patch via FreeBSD bugzilla. It fixes building on FreeBSD with Python 3.8 and onward. I've patched the port for now but it would be great if you could include it in the next release.