### PR TITLE
Fix: Initialize `message` to prevent check uninitialized error

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -6953,6 +6953,8 @@ class CheckVersion(QObject):
                               'Get it at <a href={1}>{1}</a>.'.format(latest_version, AppInfo.WEBSITE + '/download')
                 else:
                     message = ''
+            else:
+                message = ''
 
             # check if there is anything to tell
             if message != '':


### PR DESCRIPTION
A small startup fix to prevent this:

```
Traceback (most recent call last):
  File "/usr/lib/python3/site-packages/Nagstamon/QUI/__init__.py", line 6982, in check
    if message != '':
UnboundLocalError: local variable 'message' referenced before assignment
```