### PR TITLE
add filter for alertmanager request url

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -962,6 +962,7 @@ class Server(object):
         self.map_to_hostname = "pod_name,namespace,instance"
         self.map_to_servicename = "alertname"
         self.map_to_status_information = "message,summary,description"
+        self.alertmanager_filter = ''
 
 class Action(object):
     """

--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5762,7 +5762,9 @@ class Dialog_Server(Dialog):
             self.ui.label_map_to_servicename: ['Prometheus','Alertmanager'],
             self.ui.input_lineedit_map_to_servicename: ['Prometheus','Alertmanager'],
             self.ui.label_map_to_status_information: ['Prometheus','Alertmanager'],
-            self.ui.input_lineedit_map_to_status_information: ['Prometheus','Alertmanager']}
+            self.ui.input_lineedit_map_to_status_information: ['Prometheus','Alertmanager'],
+            self.ui.input_lineedit_alertmanager_filter: ['Alertmanager'],
+            self.ui.label_alertmanager_filter: ['Alertmanager']}
 
         # to be used when selecting authentication method Kerberos
         self.AUTHENTICATION_WIDGETS = [

--- a/Nagstamon/QUI/settings_server.py
+++ b/Nagstamon/QUI/settings_server.py
@@ -325,6 +325,12 @@ class Ui_settings_server(object):
         self.input_checkbox_use_description_name_service = QtWidgets.QCheckBox(self.groupbox_options)
         self.input_checkbox_use_description_name_service.setObjectName("input_checkbox_use_description_name_service")
         self.gridLayout_3.addWidget(self.input_checkbox_use_description_name_service, 19, 1, 1, 3)
+        self.label_alertmanager_filter = QtWidgets.QLabel(self.groupbox_options)
+        self.label_alertmanager_filter.setObjectName("label_alertmanager_filter")
+        self.gridLayout_3.addWidget(self.label_alertmanager_filter, 12, 1, 1, 1)
+        self.input_lineedit_alertmanager_filter = QtWidgets.QLineEdit(self.groupbox_options)
+        self.input_lineedit_alertmanager_filter.setObjectName("input_lineedit_alertmanager_filter")
+        self.gridLayout_3.addWidget(self.input_lineedit_alertmanager_filter, 12, 2, 1, 2)
         self.gridLayout.addWidget(self.groupbox_options, 28, 0, 1, 4)
 
         self.retranslateUi(settings_server)
@@ -395,3 +401,4 @@ class Ui_settings_server(object):
         self.label_host_filter.setText(_translate("settings_server", "Host filter:"))
         self.label_timeout.setText(_translate("settings_server", "Timeout:"))
         self.input_checkbox_use_description_name_service.setText(_translate("settings_server", "Use description as service name"))
+        self.label_alertmanager_filter.setText(_translate("settings_server", "Filter:"))

--- a/Nagstamon/QUI/settings_server.ui
+++ b/Nagstamon/QUI/settings_server.ui
@@ -640,6 +640,16 @@
         </property>
        </widget>
       </item>
+      <item row="12" column="1">
+       <widget class="QLabel" name="label_alertmanager_filter">
+        <property name="text">
+         <string>Filter:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="2" colspan="2">
+       <widget class="QLineEdit" name="input_lineedit_alertmanager_filter"/>
+      </item>
      </layout>
     </widget>
    </item>

--- a/Nagstamon/Servers/Alertmanager.py
+++ b/Nagstamon/Servers/Alertmanager.py
@@ -82,6 +82,7 @@ class AlertmanagerServer(PrometheusServer):
 
     API_PATH_ALERTS = "/api/v2/alerts"
     API_PATH_SILENCES = "/api/v2/silences"
+    API_FILTERS = '?filter='
 
     def _get_status(self):
         """
@@ -91,12 +92,16 @@ class AlertmanagerServer(PrometheusServer):
             self.Debug(server=self.get_name(),debug="detection config (map_to_status_information): '" + str(self.map_to_status_information) + "'")
             self.Debug(server=self.get_name(),debug="detection config (map_to_hostname): '" + str(self.map_to_hostname) + "'")
             self.Debug(server=self.get_name(),debug="detection config (map_to_servicename): '" + str(self.map_to_servicename) + "'")
+            self.Debug(server=self.get_name(),debug="detection config (alertmanager_filter): '" + str(self.alertmanager_filter) + "'")
 
         # get all alerts from the API server
         try:
-            result = self.FetchURL(self.monitor_url + self.API_PATH_ALERTS,
-                                   giveback="raw")
-            
+            if self.alertmanager_filter != '':
+                result = self.FetchURL(self.monitor_url + self.API_PATH_ALERTS + self.API_FILTERS + self.alertmanager_filter,
+                                       giveback="raw")
+            else:
+                result = self.FetchURL(self.monitor_url + self.API_PATH_ALERTS,
+                                       giveback="raw")
             if conf.debug_mode:
                 self.Debug(server=self.get_name(),debug="received status code '" + str(result.status_code) + "' with this content in result.result: \n\
 -----------------------------------------------------------------------------------------------------------------------------\n\
@@ -172,7 +177,7 @@ class AlertmanagerServer(PrometheusServer):
                 else:
                     if conf.debug_mode:
                         self.Debug(server=self.get_name(),debug="[" + alert['fingerprint'] + "]: detected status: '" + service.attempt + "'")
-                
+
                 service.duration = str(self._get_duration(alert["startsAt"]))
 
                 # Alertmanager specific extensions

--- a/Nagstamon/Servers/__init__.py
+++ b/Nagstamon/Servers/__init__.py
@@ -196,6 +196,7 @@ def create_server(server=None):
     new_server.use_description_name_service = server.use_description_name_service
 
     # Prometheus & Alertmanager
+    new_server.alertmanager_filter = server.alertmanager_filter
     new_server.map_to_hostname = server.map_to_hostname
     new_server.map_to_servicename = server.map_to_servicename
     new_server.map_to_status_information = server.map_to_status_information


### PR DESCRIPTION
Alertmanager offers filtering thanks to API requests. 
This feature allows to set a filtering rule (by passing it directly in the URL)

The problem :
#699
We can solve this with a filter like : `{envrionnement%3D"production"}`