### PR TITLE
added unittests to alertmanager

### DIFF
--- a/.github/workflows/build-release-latest.yml
+++ b/.github/workflows/build-release-latest.yml
@@ -9,6 +9,34 @@ env:
   repo_dir: nagstamon-jekyll/docs/repo
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libkrb5-dev
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pylint
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with unittest
+      run: |
+        python -m unittest tests/test_Alertmanager.py
+
   debian:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-release-stable.yml
+++ b/.github/workflows/build-release-stable.yml
@@ -8,6 +8,34 @@ env:
   repo_dir: nagstamon-jekyll/docs/repo
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libkrb5-dev
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pylint
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with unittest
+      run: |
+        python -m unittest tests/test_Alertmanager.py
+
   debian:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *.pyc
 *~
 .idea/
-.__pycache__/
+__pycache__/
 *.swp
 nagstamon.conf/
 .directory
 .metadata/
 .vscode/
+dist/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
-nagstamon (3.7-20210408) unstable; urgency=low
+nagstamon (3.7-20210517) unstable; urgency=low
   * New upstream
+   - added test section to GitHub actions workflows to enable testing
+   - added basic unit tests and linting to Alertmanager
 
  -- Henri Wahl <henri@nagstamon.de> Tue, 07 Apr 2021 19:00:00 +0100
 

--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -124,7 +124,7 @@ class AppInfo(object):
         contains app information previously located in GUI.py
     """
     NAME = 'Nagstamon'
-    VERSION = '3.7-20210515'
+    VERSION = '3.7-20210518'
     WEBSITE = 'https://nagstamon.de'
     COPYRIGHT = '©2008-2021 Henri Wahl et al.'
     COMMENTS = 'Nagios status monitor for your desktop'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+beautifulsoup4
+bs4
+keyring
+lxml
+psutil
+PyQt5
+PySocks
+python-dateutil
+requests
+requests-kerberos

--- a/tests/test_Alertmanager.py
+++ b/tests/test_Alertmanager.py
@@ -1,0 +1,141 @@
+import re
+import sys
+import json
+
+from pylint import lint
+
+import unittest
+import logging
+import Nagstamon
+import Nagstamon.Servers.Alertmanager
+
+conf = {}
+conf['debug_mode'] = True
+
+def read_file(filename):
+    '''
+        Helper method for injecting json from files
+    '''
+    with open(filename) as f:
+        return f.read()
+
+
+class test_Alertmanager(unittest.TestCase):
+
+    def test_lint_with_pylint(self):
+        with self.assertRaises(SystemExit) as cm:
+            lint.Run(['--errors-only','Nagstamon/Servers/Alertmanager.py'])
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_unit_alert_suppressed(self):
+        with open('tests/test_Alertmanager_suppressed.json') as json_file:
+            data = json.load(json_file)
+        
+        test_class = Nagstamon.Servers.Alertmanager.AlertmanagerServer()
+        test_class.map_to_hostname = 'instance,pod_name,namespace'
+        test_class.map_to_servicename = 'alertname'
+        test_class.map_to_status_information = 'message,summary,description'
+
+        test_result = test_class._process_alert(data)
+
+        self.assertEqual(test_result['attempt'], 'suppressed')
+        self.assertEqual(test_result['acknowledged'], True)
+        self.assertEqual(test_result['scheduled_downtime'], True)
+        self.assertEqual(test_result['host'], '127.0.0.1')
+        self.assertEqual(test_result['name'], 'Error')
+        self.assertEqual(test_result['server'], '')
+        self.assertEqual(test_result['status'], 'WARNING')
+        self.assertEqual(test_result['labels'], {"alertname":"Error","device":"murpel","endpoint":"metrics","instance":"127.0.0.1:9100","job":"node-exporter","namespace":"monitoring","pod":"monitoring-prometheus-node-exporter-4711","prometheus":"monitoring/monitoring-prometheus-oper-prometheus","service":"monitoring-prometheus-node-exporter","severity":"warning"})
+        self.assertEqual(test_result['generatorURL'], 'http://localhost')
+        self.assertEqual(test_result['fingerprint'], '0ef7c4bd7a504b8d')
+        self.assertEqual(test_result['status_information'], 'Network interface "murpel" showing errors on node-exporter monitoring/monitoring-prometheus-node-exporter-4711')
+
+
+    def test_unit_alert_skipped(self):
+        with open('tests/test_Alertmanager_skipped.json') as json_file:
+            data = json.load(json_file)
+
+        test_class = Nagstamon.Servers.Alertmanager.AlertmanagerServer()
+        test_class.map_to_hostname = 'instance,pod_name,namespace'
+        test_class.map_to_servicename = 'alertname'
+        test_class.map_to_status_information = 'message,summary,description'
+
+        test_result = test_class._process_alert(data)
+
+        self.assertEqual(test_result, False)
+
+
+    def test_unit_alert_warning(self):
+        with open('tests/test_Alertmanager_warning.json') as json_file:
+            data = json.load(json_file)
+
+        test_class = Nagstamon.Servers.Alertmanager.AlertmanagerServer()
+        test_class.map_to_hostname = 'instance,pod_name,namespace'
+        test_class.map_to_servicename = 'alertname'
+        test_class.map_to_status_information = 'message,summary,description'
+
+        test_result = test_class._process_alert(data)
+
+        self.assertEqual(test_result['attempt'], 'active')
+        self.assertEqual(test_result['acknowledged'], False)
+        self.assertEqual(test_result['scheduled_downtime'], False)
+        self.assertEqual(test_result['host'], 'unknown')
+        self.assertEqual(test_result['name'], 'TargetDown')
+        self.assertEqual(test_result['server'], '')
+        self.assertEqual(test_result['status'], 'WARNING')
+        self.assertEqual(test_result['labels'], {"alertname": "TargetDown","job": "kubelet","prometheus": "monitoring/monitoring-prometheus-oper-prometheus","severity": "warning"})
+        self.assertEqual(test_result['generatorURL'], 'http://localhost')
+        self.assertEqual(test_result['fingerprint'], '7be970c6e97b95c9')
+        self.assertEqual(test_result['status_information'], '66.6% of the kubelet targets are down.')
+
+
+    def test_unit_alert_critical(self):
+        with open('tests/test_Alertmanager_critical.json') as json_file:
+            data = json.load(json_file)
+        
+        test_class = Nagstamon.Servers.Alertmanager.AlertmanagerServer()
+        test_class.map_to_hostname = 'instance,pod_name,namespace'
+        test_class.map_to_servicename = 'alertname'
+        test_class.map_to_status_information = 'message,summary,description'
+
+        test_result = test_class._process_alert(data)
+
+        self.assertEqual(test_result['attempt'], 'active')
+        self.assertEqual(test_result['acknowledged'], False)
+        self.assertEqual(test_result['scheduled_downtime'], False)
+        self.assertEqual(test_result['host'], '127.0.0.1')
+        self.assertEqual(test_result['name'], 'Error')
+        self.assertEqual(test_result['server'], '')
+        self.assertEqual(test_result['status'], 'ERROR')
+        self.assertEqual(test_result['labels'], {"alertname":"Error","device":"murpel","endpoint":"metrics","instance":"127.0.0.1:9100","job":"node-exporter","namespace":"monitoring","pod":"monitoring-prometheus-node-exporter-4711","prometheus":"monitoring/monitoring-prometheus-oper-prometheus","service":"monitoring-prometheus-node-exporter","severity":"error"})
+        self.assertEqual(test_result['generatorURL'], 'http://localhost')
+        self.assertEqual(test_result['fingerprint'], '0ef7c4bd7a504b8d')
+        self.assertEqual(test_result['status_information'], 'Network interface "murpel" showing errors on node-exporter monitoring/monitoring-prometheus-node-exporter-4711')
+
+
+    def test_unit_alert_critical_with_empty_maps(self):
+        with open('tests/test_Alertmanager_critical.json') as json_file:
+            data = json.load(json_file)
+        
+        test_class = Nagstamon.Servers.Alertmanager.AlertmanagerServer()
+        test_class.map_to_hostname = ''
+        test_class.map_to_servicename = ''
+        test_class.map_to_status_information = ''
+
+        test_result = test_class._process_alert(data)
+
+        self.assertEqual(test_result['attempt'], 'active')
+        self.assertEqual(test_result['acknowledged'], False)
+        self.assertEqual(test_result['scheduled_downtime'], False)
+        self.assertEqual(test_result['host'], 'unknown')
+        self.assertEqual(test_result['name'], 'unknown')
+        self.assertEqual(test_result['server'], '')
+        self.assertEqual(test_result['status'], 'ERROR')
+        self.assertEqual(test_result['labels'], {"alertname":"Error","device":"murpel","endpoint":"metrics","instance":"127.0.0.1:9100","job":"node-exporter","namespace":"monitoring","pod":"monitoring-prometheus-node-exporter-4711","prometheus":"monitoring/monitoring-prometheus-oper-prometheus","service":"monitoring-prometheus-node-exporter","severity":"error"})
+        self.assertEqual(test_result['generatorURL'], 'http://localhost')
+        self.assertEqual(test_result['fingerprint'], '0ef7c4bd7a504b8d')
+        self.assertEqual(test_result['status_information'], '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_Alertmanager_critical.json
+++ b/tests/test_Alertmanager_critical.json
@@ -1,0 +1,32 @@
+{
+    "annotations": {
+        "message": "Network interface \"murpel\" showing errors on node-exporter monitoring/monitoring-prometheus-node-exporter-4711"
+    },
+    "endsAt": "1970-01-01T00:00:12.345Z",
+    "fingerprint": "0ef7c4bd7a504b8d",
+    "receivers": [
+        {
+            "name": "null"
+        }
+    ],
+    "startsAt": "1970-01-01T00:00:01.345Z",
+    "status": {
+        "inhibitedBy": [],
+        "silencedBy": [],
+        "state": "active"
+    },
+    "updatedAt": "1970-01-01T00:00:12.345Z",
+    "generatorURL": "http://localhost",
+    "labels": {
+        "alertname": "Error",
+        "device": "murpel",
+        "endpoint": "metrics",
+        "instance": "127.0.0.1:9100",
+        "job": "node-exporter",
+        "namespace": "monitoring",
+        "pod": "monitoring-prometheus-node-exporter-4711",
+        "prometheus": "monitoring/monitoring-prometheus-oper-prometheus",
+        "service": "monitoring-prometheus-node-exporter",
+        "severity": "error"
+    }
+}

--- a/tests/test_Alertmanager_skipped.json
+++ b/tests/test_Alertmanager_skipped.json
@@ -1,0 +1,22 @@
+{
+    "labels": {
+        "alertname": "Watchdog",
+        "prometheus": "monitoring/monitoring-prometheus-oper-prometheus",
+        "severity": "none"
+    },
+    "annotations": {
+        "message": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n"
+    },
+    "startsAt": "1970-01-01T00:00:00.520032135Z",
+    "endsAt": "1970-01-01T00:00:00.520032135Z",
+    "generatorURL": "http://localhost",
+    "status": {
+        "state": "active",
+        "silencedBy": [],
+        "inhibitedBy": []
+    },
+    "receivers": [
+        "null"
+    ],
+    "fingerprint": "1b43ca4565de75d2"
+}

--- a/tests/test_Alertmanager_suppressed.json
+++ b/tests/test_Alertmanager_suppressed.json
@@ -1,0 +1,34 @@
+{
+    "annotations": {
+        "message": "Network interface \"murpel\" showing errors on node-exporter monitoring/monitoring-prometheus-node-exporter-4711"
+    },
+    "endsAt": "1970-01-01T00:00:12.345Z",
+    "fingerprint": "0ef7c4bd7a504b8d",
+    "receivers": [
+        {
+            "name": "null"
+        }
+    ],
+    "startsAt": "1970-01-01T00:00:01.345Z",
+    "status": {
+        "inhibitedBy": [],
+        "silencedBy": [
+            "bb043288-42a0-4315-8bae-15cde1d7e239"
+        ],
+        "state": "suppressed"
+    },
+    "updatedAt": "1970-01-01T00:00:12.345Z",
+    "generatorURL": "http://localhost",
+    "labels": {
+        "alertname": "Error",
+        "device": "murpel",
+        "endpoint": "metrics",
+        "instance": "127.0.0.1:9100",
+        "job": "node-exporter",
+        "namespace": "monitoring",
+        "pod": "monitoring-prometheus-node-exporter-4711",
+        "prometheus": "monitoring/monitoring-prometheus-oper-prometheus",
+        "service": "monitoring-prometheus-node-exporter",
+        "severity": "warning"
+    }
+}

--- a/tests/test_Alertmanager_warning.json
+++ b/tests/test_Alertmanager_warning.json
@@ -1,0 +1,24 @@
+{
+    "labels": {
+        "alertname": "TargetDown",
+        "job": "kubelet",
+        "prometheus": "monitoring/monitoring-prometheus-oper-prometheus",
+        "severity": "warning"
+    },
+    "annotations": {
+        "message": "66.6% of the kubelet targets are down."
+    },
+    "startsAt": "1970-01-01T00:00:00.520032135Z",
+    "endsAt": "1970-01-01T00:00:00.520032135Z",
+    "updatedAt": "1970-01-01T00:00:00.520032135Z",
+    "generatorURL": "http://localhost",
+    "status": {
+        "state": "active",
+        "silencedBy": [],
+        "inhibitedBy": []
+    },
+    "receivers": [
+        "null"
+    ],
+    "fingerprint": "7be970c6e97b95c9"
+}


### PR DESCRIPTION
I just refactored Alertmanager.py so it is possible to be able to run unittests on it.
I also added basic tests and added a test section in the GitHub workflow files. Finally I switched to the logging module because it allows analyzing of log outputs with unittest.
Using test driven development should really help increasing quality so I hope that this PR will soon get merged.