### PR TITLE
add requests-ecp dependency

### DIFF
--- a/build/requirements/linux.txt
+++ b/build/requirements/linux.txt
@@ -7,4 +7,5 @@ pysocks
 python-dateutil
 requests
 requests-kerberos
+requests-ecp
 setuptools==44.1.1

--- a/build/requirements/macos.txt
+++ b/build/requirements/macos.txt
@@ -8,4 +8,5 @@ pysocks
 python-dateutil
 requests
 requests-gssapi
+requests-ecp
 setuptools==44.1.1

--- a/build/requirements/windows.txt
+++ b/build/requirements/windows.txt
@@ -11,5 +11,6 @@ pysocks
 python-dateutil
 requests
 requests-kerberos
+requests-ecp
 setuptools==44.1.1
 wheel


### PR DESCRIPTION
I forgot this dependency in my previous PR.

As it will only concern very few people, a better solution would probably to make this dependency optional, and just avoid proposing ECP authentication if loading fail. The same could apply to Kerberos authentication, actually. However, if your main target audience is people using pre-built distributions with all dependencies included, or people building from sources fetching those dependencies directly from PyPi, and not people trying to minimize dependencies to required one only, this seems just useless technical complexity.