### PR TITLE
Fix SnagView interpreting all up and ok as pending

### DIFF
--- a/Nagstamon/Servers/SnagView3.py
+++ b/Nagstamon/Servers/SnagView3.py
@@ -198,7 +198,7 @@ class SnagViewServer(GenericServer):
                 h = dict(host)
 
                 # Skip if Host is 'Pending'
-                if int(h['sv_host__nagios_status__current_state'] or 4) == 4:
+                if int(h['sv_host__nagios_status__current_state']) == 4:
                     continue
 
                 # host
@@ -279,8 +279,8 @@ class SnagViewServer(GenericServer):
                 s = dict(service)
 
                 # Skip if Host or Service is 'Pending'
-                if int(s['sv_service_status__nagios_status__current_state'] or 4) == 4 or int(
-                        s['sv_host__nagios_status__current_state'] or 4) == 4:
+                if int(s['sv_service_status__nagios_status__current_state']) == 4 or int(
+                        s['sv_host__nagios_status__current_state']) == 4:
                     continue
 
                 # host and service


### PR DESCRIPTION
If i execute this in python: print(int(0 or 4))
It always prints the number 4. So all Hosts and Services which are Up or Ok will be skipped because Nagstamon thinks they are pending (Status 4).