### PR TITLE
fix zabbix crash closing unclosable event

### DIFF
--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -500,8 +500,13 @@ class ZabbixServer(GenericServer):
                 # 16 - unacknowledge event
                 actions = 0
                 # If sticky is set then close only current event
-                if triggerid == service and sticky is True:
-                    actions |= 1
+                if triggerid == service and sticky:
+                    # do not send the "Close" flag if this event does not allow manual closing
+                    triggers = self.zapi.trigger.get({
+                        'output': ['triggerid', 'manual_close'],
+                        'filter': {'triggerid': triggerid}})
+                    if not triggers or 'manual_close' not in triggers[0] or triggers[0]['manual_close'] == 1:
+                        actions |= 1
                 # The current Nagstamon menu items don't match up too well with the Zabbix actions,
                 # but perhaps "Persistent comment" is the closest thing to acknowledgement
                 if persistent:


### PR DESCRIPTION
Zabbix 5.4

If you try to "Sticky acknowledge" (close) a Zabbix event when the event does not allow manual closing, Nagstamon will crash and you will get the following error:
```
Nagstamon.thirdparty.zabbix_api.ZabbixAPIException: ('Error -32500: Application error., Cannot close problem: trigger does not allow manual closing. while sending {"jsonrpc": "2.0", "method": "event.acknowledge", "params": {"eventids": ["201048"], "message": "", "action": 1}, "auth": "b3034098e612304a36363ec925c3e345", "id": 56}', -32500)
```
This change makes an extra API call to determine if the event can be closed before trying to close it.