### PR TITLE
zabbix account for expired maintenance

### DIFF
--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -553,8 +553,7 @@ class ZabbixServer(GenericServer):
         if app:
             body['tags'] = [{'tag': 'Application', 'operator': 0, 'value': app}]
             body['description'] += ' ' + body['name']
-            body['name'] = f'{hostname} {app}'
-
+            body['name'] = f'{start_time} {hostname} {app}'
         try:
             self.zapi.maintenance.create(body)
         except Already_Exists:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5019061/129505718-5d605106-6728-49f5-a5b7-5423aae5eb8a.png)

Sorry to change this again, but I found another issue. Zabbix maintenance periods are not removed after they expire. This means I need to include the datetime in the name of the maintenance period so that it remains unique. Otherwise Zabbix API will reject the request.