### PR TITLE
Allow to use display_name on services with Thruk

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5754,7 +5754,7 @@ class Dialog_Server(Dialog):
             self.ui.label_autologin_key: ['Centreon', 'monitos4x', 'Thruk'],
             self.ui.input_checkbox_no_cookie_auth: ['IcingaWeb2', 'Sensu'],
             self.ui.input_checkbox_use_display_name_host: ['Icinga', 'IcingaWeb2'],
-            self.ui.input_checkbox_use_display_name_service: ['Icinga', 'IcingaWeb2'],
+            self.ui.input_checkbox_use_display_name_service: ['Icinga', 'IcingaWeb2', 'Thruk'],
             self.ui.input_checkbox_use_description_name_service: ['Zabbix'],
             self.ui.input_checkbox_force_authuser: ['Checkmk Multisite'],
             self.ui.groupbox_checkmk_views: ['Checkmk Multisite'],

--- a/Nagstamon/Servers/Thruk.py
+++ b/Nagstamon/Servers/Thruk.py
@@ -229,6 +229,36 @@ class ThrukServer(GenericServer):
         except:
             traceback.print_exc(file=sys.stdout)
 
+    def _set_downtime(self, host, service, author, comment, fixed, start_time, end_time, hours, minutes):
+        '''
+            finally send downtime command to monitor server
+        '''
+        url = self.monitor_cgi_url + '/cmd.cgi'
+
+        # for some reason Icinga is very fastidiuos about the order of CGI arguments, so please
+        # here we go... it took DAYS :-(
+        cgi_data = OrderedDict()
+        if service == '':
+            cgi_data['cmd_typ'] = '55'
+        else:
+            cgi_data['cmd_typ'] = '56'
+        cgi_data['cmd_mod'] = '2'
+        cgi_data['trigger'] = '0'
+        cgi_data['host'] = host
+        if service != '':
+            cgi_data['service'] = self.hosts[host].services[ service ].real_name
+        cgi_data['com_author'] = author
+        cgi_data['com_data'] = comment
+        cgi_data['fixed'] = fixed
+        cgi_data['start_time'] = start_time
+        cgi_data['end_time'] = end_time
+        cgi_data['hours'] = hours
+        cgi_data['minutes'] = minutes
+        cgi_data['btnSubmit'] = 'Commit'
+
+        # running remote cgi command
+        self.FetchURL(url, giveback='raw', cgi_data=cgi_data)
+
     def _get_status(self):
         """
             Get status from Thruk Server


### PR DESCRIPTION
Hi,

I'm not fluent in Python, so it's not a pretty patch, but it's something ¯\_(ツ)_/¯

I use Thruk and display_name on services. I saw that it was enabled on Icinga, so I tried to do the same for Thruk.

Know issues:
- I didn't do the display_name for Host, only for services
- ~~on services with specific display_name, only the Monitor link work~~

Best regards, 