### PR TITLE
Fix : Remove line returns from a Host status information

### DIFF
--- a/Nagstamon/Servers/Centreon.py
+++ b/Nagstamon/Servers/Centreon.py
@@ -646,7 +646,7 @@ class CentreonServer(GenericServer):
                         self.new_hosts[str(l.hn.text)].status_type = self.HARD_SOFT[self.new_hosts[str(l.hn.text)].status_type]
                         self.new_hosts[str(l.hn.text)].last_check = str(l.lc.text)
                         self.new_hosts[str(l.hn.text)].duration = str(l.lsc.text)
-                        self.new_hosts[str(l.hn.text)].status_information= str(l.ou.text)
+                        self.new_hosts[str(l.hn.text)].status_information = str(l.ou.text).replace('\n', ' ').strip()
                         if l.find('cih') != None:
                             self.new_hosts[str(l.hn.text)].criticality = str(l.cih.text)
                         else:


### PR DESCRIPTION
Hello,
This fix replace line returns with a space from a Centreon Host status information (exactly as it is done with status information)

This prevents this behavior :
![before](https://user-images.githubusercontent.com/9086425/167611581-767115c0-ae30-4eeb-93a6-7f3fe14f1058.png)

After the fix : 
![after](https://user-images.githubusercontent.com/9086425/167611604-b21fc96f-37dc-467b-8376-a77d78605dd8.png)

