### PR TITLE
Fix zabbix bugs regarding timeout, ack/closing, and duplicate services

### DIFF
--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -1245,47 +1245,6 @@ class GenericServer(object):
                             self.nagitems_filtered['services']['UNKNOWN'].append(service)
                             self.unknown += 1
 
-                    # zabbix support
-                    if service.status == "INFORMATION":
-                        if conf.filter_all_unknown_services is True:
-                            if conf.debug_mode:
-                                self.Debug(server=self.get_name(),
-                                        debug="Filter: INFORMATION " + str(host.name) + ";" + str(service.name))
-                            service.visible = False
-                        else:
-                            self.nagitems_filtered["services"]["INFORMATION"].append(service)
-                            self.information += 1
-
-                    if service.status == "AVERAGE":
-                        if conf.filter_all_unknown_services is True:
-                            if conf.debug_mode:
-                                self.Debug(server=self.get_name(),
-                                        debug="Filter: AVERAGE " + str(host.name) + ";" + str(service.name))
-                            service.visible = False
-                        else:
-                            self.nagitems_filtered["services"]["AVERAGE"].append(service)
-                            self.average += 1
-
-                    if service.status == "HIGH":
-                        if conf.filter_all_unknown_services is True:
-                            if conf.debug_mode:
-                                self.Debug(server=self.get_name(),
-                                        debug="Filter: HIGH " + str(host.name) + ";" + str(service.name))
-                            service.visible = False
-                        else:
-                            self.nagitems_filtered["services"]["HIGH"].append(service)
-                            self.high += 1
-
-                    if service.status == "DISASTER":
-                        if conf.filter_all_unknown_services is True:
-                            if conf.debug_mode:
-                                self.Debug(server=self.get_name(),
-                                        debug="Filter: DISASTER " + str(host.name) + ";" + str(service.name))
-                            service.visible = False
-                        else:
-                            self.nagitems_filtered["services"]["DISASTER"].append(service)
-                            self.disaster += 1
-
                 # Add service flags for status icons in treeview
                 if service.acknowledged:
                     service.service_flags += 'A'


### PR DESCRIPTION
1. deleted some commented code
2. In the Generic.py file, the below deleted code is redundant, and was causing Zabbix (and likely other monitoring systems) to display duplicate services
3. I now pass the "timeout" configured in settings to the ZabbixAPI. This fixes an issue to allow configuring a timeout longer than 10 seconds, which is required if your Zabbix instance is rather large.
4. Fixed a regression bug that removed the ability to "close" problems from Nagstamon