### PR TITLE
Fix centreonAPI JSONDecodeError after getting a token

### DIFF
--- a/Nagstamon/Servers/Centreon/CentreonAPI.py
+++ b/Nagstamon/Servers/Centreon/CentreonAPI.py
@@ -708,6 +708,7 @@ class CentreonServer(GenericServer):
             # This request must be done in a GET, so just encode the parameters and fetch
             result = self.FetchURL(self.urls_centreon['resources'] + '?' + urllib.parse.urlencode(cgi_data), giveback="raw")
             if result.status_code == 403:
+                result = self.FetchURL(self.urls_centreon['resources'] + '?' + urllib.parse.urlencode(cgi_data), giveback="raw")
                 self.get_token()
             data = json.loads(result.result)
             error = result.error


### PR DESCRIPTION
Replay the request after getting a new token, otherwise result.result will be empty and it will throw an error "Error : json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)"