### PR TITLE
Fixed mutual default argument in methods.

### DIFF
--- a/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
@@ -328,7 +328,7 @@ class AlertmanagerServer(GenericServer):
 
 
     def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent,
-                         all_services=[], expire_time=None):
+                         all_services=None, expire_time=None):
         alert = self.hosts[host].services[service]
         ends_at = convert_timestring_to_utc(expire_time)
 

--- a/Nagstamon/Servers/Centreon/CentreonAPI.py
+++ b/Nagstamon/Servers/Centreon/CentreonAPI.py
@@ -431,7 +431,7 @@ class CentreonServer(GenericServer):
         # return True if all worked well
         return Result()
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         try:
 
             acknowledgements = {
@@ -474,8 +474,8 @@ class CentreonServer(GenericServer):
                                debug="Set Ack on Host, status code : " + str(status_code))
 
             # Service
-            if service != '' or len(all_services) > 0:
-                if len(all_services) == 0:
+            if service != '' or all_services:
+                if not all_services:
                     all_services = [service]
 
                 for s in all_services:

--- a/Nagstamon/Servers/Centreon/CentreonLegacy.py
+++ b/Nagstamon/Servers/Centreon/CentreonLegacy.py
@@ -844,7 +844,7 @@ class CentreonServer(GenericServer):
         return Result()
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         # decision about host or service - they have different URLs
         try:
             if service == '':
@@ -873,11 +873,12 @@ class CentreonServer(GenericServer):
 
             # if host is acknowledged and all services should be to or if a service is acknowledged
             # (and all other on this host too)
-            if service != '' or len(all_services) > 0:
+            if service != '' or all_services:
                 # service(s) @ host
                 # if all_services is empty only one service has to be checked - the one clicked
                 # otherwise if there all services should be acknowledged
-                if len(all_services) == 0: all_services = [service]
+                if not all_services:
+                    all_services = [service]
 
                 # acknowledge all services on a host
                 for s in all_services:

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -412,7 +412,7 @@ class GenericServer(object):
                               all_services)
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         '''
             send acknowledge to monitor server - might be different on every monitor type
         '''
@@ -452,7 +452,7 @@ class GenericServer(object):
         self.FetchURL(url, giveback='raw', cgi_data=cgi_data)
 
         # acknowledge all services on a host
-        if len(all_services) > 0:
+        if all_services:
             for s in all_services:
                 cgi_data['cmd_typ'] = '34'
                 cgi_data['service'] = s

--- a/Nagstamon/Servers/Icinga.py
+++ b/Nagstamon/Servers/Icinga.py
@@ -634,7 +634,7 @@ class IcingaServer(GenericServer):
         self.FetchURL(self.monitor_cgi_url + '/cmd.cgi', giveback='raw', cgi_data=cgi_data)
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         '''
             send acknowledge to monitor server
             extra _method necessary due to https://github.com/HenriWahl/Nagstamon/issues/192
@@ -680,7 +680,7 @@ class IcingaServer(GenericServer):
         self.FetchURL(url, giveback='raw', cgi_data=cgi_data)
 
         # acknowledge all services on a host
-        if len(all_services) > 0:
+        if all_services:
             for s in all_services:
                 cgi_data['cmd_typ'] = '34'
                 cgi_data['service'] = s

--- a/Nagstamon/Servers/Icinga2API.py
+++ b/Nagstamon/Servers/Icinga2API.py
@@ -209,7 +209,7 @@ class Icinga2APIServer(GenericServer):
         pass
 
     def _set_acknowledge(self, host, service, author, comment, sticky,
-                         notify, persistent, all_services=[]):
+                         notify, persistent, all_services=None):
         '''
         Send acknowledge to monitor server
         '''

--- a/Nagstamon/Servers/IcingaWeb2.py
+++ b/Nagstamon/Servers/IcingaWeb2.py
@@ -406,7 +406,7 @@ class IcingaWeb2Server(GenericServer):
                               info_dict['expire_time'])
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[], expire_time=None):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None, expire_time=None):
         # First retrieve the info page for this host/service
         if service == '':
             # url = self.monitor_cgi_url + '/monitoring/host/acknowledge-problem?host=' + host

--- a/Nagstamon/Servers/Monitos4x.py
+++ b/Nagstamon/Servers/Monitos4x.py
@@ -456,7 +456,7 @@ class Monitos4xServer(GenericServer):
         else:
             self.session.post('{0}/api/{1}/{2}/reschedule'.format(self.monitor_url, type ,uuid))
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         """
             Do a POST-Request to set an acknowledgement for a host, service or host with all services in monitos 4
 
@@ -467,13 +467,13 @@ class Monitos4xServer(GenericServer):
             :param sticky: Bool - Sticky Acknowledgement
             :param notify: Bool - Send Notifications
             :param persistent: Bool - Persistent comment
-            :param all_services: Array - List of all services (filled only if 'Acknowledge all services on host' is set)
+            :param all_services: Optional[Array] - List of all services (filled only if 'Acknowledge all services on host' is set)
         """
         form_data = dict()
 
         type = 'host'
 
-        if len(all_services) > 0:  # Host & all Services
+        if all_services:  # Host & all Services
             uuid = self.hosts[host].uuid
             form_data = json.dumps(
                 {'comment': comment, 'notify': int(notify), 'persistent': int(persistent),

--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -516,7 +516,7 @@ class MultisiteServer(GenericServer):
                            debug='Invalid start/end date/time given')
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         p = {
             '_acknowledge':    'Acknowledge',
             '_ack_sticky':     sticky == 1 and 'on' or '',
@@ -527,8 +527,9 @@ class MultisiteServer(GenericServer):
         self._action(self.hosts[host].site, host, service, p)
 
         # acknowledge all services on a host when told to do so
-        for s in all_services:
-            self._action(self.hosts[host].site, host, s, p)
+        if all_services:
+            for s in all_services:
+                self._action(self.hosts[host].site, host, s, p)
 
 
     def _set_recheck(self, host, service):

--- a/Nagstamon/Servers/Opsview.py
+++ b/Nagstamon/Servers/Opsview.py
@@ -158,7 +158,7 @@ class OpsviewServer(GenericServer):
         self.FetchURL(url + cgi_data, giveback="raw", cgi_data=({ }))
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         """
             Sumit acknowledgement for host or service
         """

--- a/Nagstamon/Servers/SnagView3.py
+++ b/Nagstamon/Servers/SnagView3.py
@@ -366,7 +366,7 @@ class SnagViewServer(GenericServer):
         self.session.post(
             '{0}/rest/private/nagios/command/execute'.format(self.monitor_url), data=form_data)
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         """
             Do a POST-Request to set an acknowledgement for a host, service or host with all services in SNAG-View 3
 
@@ -377,11 +377,11 @@ class SnagViewServer(GenericServer):
             :param sticky: Bool - Sticky Acknowledgement
             :param notify: Bool - Send Notifications
             :param persistent: Bool - Persistent comment
-            :param all_services: Array - List of all services (filled only if 'Acknowledge all services on host' is set)
+            :param all_services: Optional[Array] - List of all services (filled only if 'Acknowledge all services on host' is set)
         """
         form_data = dict()
 
-        if len(all_services) > 0:  # Host & all Services
+        if all_services:  # Host & all Services
             form_data['commandType'] = 'sv_host'
             form_data['commandName'] = 'acknowledge-host-service-problems'
             form_data['params'] = json.dumps(

--- a/Nagstamon/Servers/Thruk.py
+++ b/Nagstamon/Servers/Thruk.py
@@ -151,7 +151,7 @@ class ThrukServer(GenericServer):
                        debug='Open host/service monitor web page {0}'.format(url))
         webbrowser_open(url)
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         '''
             send acknowledge to monitor server - might be different on every monitor type
         '''
@@ -191,7 +191,7 @@ class ThrukServer(GenericServer):
         self.FetchURL(url, giveback='raw', cgi_data=cgi_data)
 
         # acknowledge all services on a host
-        if len(all_services) > 0:
+        if all_services:
             for s in all_services:
                 cgi_data['cmd_typ'] = '34'
                 cgi_data['service'] = self.hosts[host].services[ s ].real_name

--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -496,7 +496,7 @@ class ZabbixServer(GenericServer):
     def set_recheck(self, info_dict):
         pass
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=[]):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         if conf.debug_mode is True:
             self.Debug(server=self.get_name(),
                        debug="Set Acknowledge Host: " + host + " Service: " + service + " Sticky: " + str(
@@ -504,6 +504,8 @@ class ZabbixServer(GenericServer):
         self._login()
         eventids = set()
         unclosable_events = set()
+        if all_services is None:
+            all_services = []
         all_services.append(service)
         get_host = self.hosts[host]
         # Through all Services

--- a/Nagstamon/Servers/op5Monitor.py
+++ b/Nagstamon/Servers/op5Monitor.py
@@ -315,7 +315,7 @@ class Op5MonitorServer(GenericServer):
         self.send_command(command, params)
 
 
-    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services):
+    def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None):
         params = {'host_name': host, 'sticky': int(sticky),
                   'notify': int(notify), 'persistent': int(persistent),
                   'comment': comment}


### PR DESCRIPTION
Got rid from a mutual default argument `all_services` in components for
server interaction.
Mutual default argument (like list in `_set_acknowledge(...)` method) can cause unpredictable behavoiur.
```
>>> def foobar(bar=[]):
...     bar.append('test')
...     print(f'List {bar} with ID {id(bar)}')
>>>
>>>
>>> foobar()
List ['test'] with ID 140147921265664
>>> foobar()
List ['test', 'test'] with ID 140147921265664  # as you see function hasn't create an empty list during second call, instead picked already existed
```
You can see more at the following topics:
https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument
https://web.archive.org/web/20200221224620id_/http://effbot.org/zone/default-values.htm

Also you can simply check a list (or any different collection) for containing items like this:
```
bar = []
if bar:
    ...
```
instead of
```
bar = []
if len(bar) > 0:
    ...
```