### PR TITLE
Add Values to ARP

### DIFF
--- a/build/windows/nagstamon.iss
+++ b/build/windows/nagstamon.iss
@@ -1,6 +1,8 @@
 [Setup]
 AppName=Nagstamon
 AppVerName=Nagstamon {#version}
+AppVersion={#version}
+AppPublisher=Henri Wahl
 DefaultDirName={commonpf}\Nagstamon
 DefaultGroupName=Nagstamon
 AlwaysUsePersonalGroup=false


### PR DESCRIPTION
When the package is installed, values for DisplayVersion and Publisher are not set in the registry. In order for other applications like [winget](microsoft/winget-cli) to properly interact with the application, these values should be set.

Current Behavior:
```
Starting package install...
Successfully installed
--> Refreshing environment variables
--> Comparing ARP Entries

DisplayName      DisplayVersion Publisher ProductCode
-----------      -------------- --------- -----------
Nagstamon 3.10.1                          {44F7CFFB-4776-4DA4-9930-A07178069517}_is1
```

New Behavior:
```
Starting package install...
Successfully installed
--> Refreshing environment variables
--> Comparing ARP Entries

DisplayName      DisplayVersion Publisher  ProductCode
---------------- -------------- ---------- -----------
Nagstamon 3.10.1 3.10.1         Henri Wahl {44F7CFFB-4776-4DA4-9930-A07178069517}_is1
```