### PR TITLE
Fallback from requests_kerberos to requests_gssapi

### DIFF
--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -69,9 +69,13 @@ if OS == OS_DARWIN:
     except ImportError:
         from requests_kerberos import HTTPKerberosAuth as HTTPSKerberos
 else:
-    # requests_gssapi needs installation of KfW - Kerberos for Windows
-    # requests_kerberoes doesn't
-    from requests_kerberos import HTTPKerberosAuth as HTTPSKerberos
+    # requests_gssapi is newer but not available everywhere
+    try:
+        # requests_gssapi needs installation of KfW - Kerberos for Windows
+        # requests_kerberoes doesn't
+        from requests_kerberos import HTTPKerberosAuth as HTTPSKerberos
+    except ImportError:
+        from requests_gssapi import HTTPSPNEGOAuth as HTTPSKerberos
 
 # disable annoying SubjectAltNameWarning warnings
 try:


### PR DESCRIPTION
RHEL/CentOS 7 has no requests_kerberos, only requests_gssapi. This patch should keep the current behaviour, just adds the fallback additionally.