### PR TITLE
Add Nagstamon RPM packages for RHEL 9 (and derivatives/clones)

### DIFF
--- a/.github/workflows/build-release-latest.yml
+++ b/.github/workflows/build-release-latest.yml
@@ -138,6 +138,19 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  rhel-9:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - run: /usr/bin/docker build -t build-nagstamon -f build/docker/Dockerfile-${{ github.job }} .
+      - run: /usr/bin/docker run -v ${{ github.workspace }}:/nagstamon build-nagstamon
+      - uses: actions/upload-artifact@v3
+        with:
+          path: build/*.rpm
+          retention-days: 1
+          if-no-files-found: error
+
   macos:
     runs-on: macos-10.15
     needs: test
@@ -252,7 +265,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [debian, fedora-34, fedora-35, fedora-36, fedora-37, macos, windows-32, windows-64, windows-64-debug]
+    needs: [debian, fedora-34, fedora-35, fedora-36, fedora-37, rhel-9, macos, windows-32, windows-64, windows-64-debug]
     steps:
       - uses: actions/download-artifact@v3
       - run: cd artifact && md5sum *agstamon* > md5sums.txt

--- a/.github/workflows/build-release-stable.yml
+++ b/.github/workflows/build-release-stable.yml
@@ -101,6 +101,19 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  rhel-9:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - run: /usr/bin/docker build -t build-nagstamon -f build/docker/Dockerfile-${{ github.job }} .
+      - run: /usr/bin/docker run -v ${{ github.workspace }}:/nagstamon build-nagstamon
+      - uses: actions/upload-artifact@v3
+        with:
+          path: build/*.rpm
+          retention-days: 1
+          if-no-files-found: error
+
   macos:
     runs-on: macos-10.15
     needs: test
@@ -188,7 +201,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [debian, fedora-34, fedora-35, fedora-36, fedora-37, macos, windows-32, windows-64]
+    needs: [debian, fedora-34, fedora-35, fedora-36, fedora-37, rhel-9, macos, windows-32, windows-64]
     steps:
       - uses: actions/download-artifact@v3
       - run: cd artifact && md5sum *agstamon* > md5sums.txt

--- a/Nagstamon/Helpers.py
+++ b/Nagstamon/Helpers.py
@@ -455,6 +455,13 @@ def get_distro():
                 if not line.startswith('#'):
                     key, value = line.split('=', 1)
                     os_release_dict[key] = value.strip('"').strip("'")
+            # Since CentOS Linux got retired by Red Hat, there are various RHEL derivatives/clones; flow is:
+            # CentOS Stream -> Red Hat Enterprise Linux -> (AlmaLinux, EuroLinux, Oracle Linux, Rocky Linux)
+            # Goal of this hack is to rule them all as Red Hat Enterprise Linux, the baseline distribution.
+            if re.search('^platform:el\d+$', os_release_dict.get('PLATFORM_ID', 'unknown')):
+                os_release_dict['ID'] = 'rhel'
+                os_release_dict['VERSION_ID'] = os_release_dict.get('VERSION_ID', 'unknown').split('.', 1)[0]
+                os_release_dict['NAME'] = 'Red Hat Enterprise Linux'
             return (os_release_dict.get('ID').lower(),
                     os_release_dict.get('VERSION_ID', 'unknown').lower(),
                     os_release_dict.get('NAME').lower())

--- a/build/build.py
+++ b/build/build.py
@@ -226,7 +226,8 @@ DISTS = {
     'debian': debmain,
     'ubuntu': debmain,
     'linuxmint': debmain,
-    'fedora': rpmmain
+    'fedora': rpmmain,
+    'rhel': rpmmain
 }
 
 if __name__ == '__main__':

--- a/build/docker/Dockerfile-rhel-9
+++ b/build/docker/Dockerfile-rhel-9
@@ -1,0 +1,30 @@
+FROM rockylinux:9
+LABEL maintainer=henri@nagstamon.de
+
+RUN dnf -y install 'dnf-command(config-manager)' \
+                   epel-release && \
+    crb enable && \
+    dnf -y install desktop-file-utils \
+                   git \
+                   python3 \
+                   python3-beautifulsoup4 \
+                   python3-cryptography \
+                   python3-dateutil \
+                   python3-devel \
+                   python3-keyring \
+                   python3-lxml \
+                   python3-psutil \
+                   python3-qt5 \
+                   python3-qt5-devel \
+                   python3-requests \
+                   python3-requests-kerberos \
+                   python3-SecretStorage \
+                   qt5-qtsvg \
+                   qt5-qtmultimedia \
+                   rpm-build
+
+# ugly workaround for legacy Qt5 on RHEL < 10
+CMD cd /nagstamon/build && \
+    sed -i s/pyqt6/pyqt5/g redhat/nagstamon.spec && \
+    sed -i s/qt6/qt5/g redhat/nagstamon.spec && \
+    /usr/bin/python3 build.py


### PR DESCRIPTION
This is a first attempt to add Nagstamon RPM packages for RHEL 9 (and derivatives/clones) - while hoping that I didn't get tricked somewhere during building and tests.

However this pull request is incomplete, because I don't know how to handle the `repo-fedora` step in `.github/workflows/build-release-{latest,stable}.yml` properly.