### PR TITLE
Add support for Opsview hashtag filtering

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -941,6 +941,9 @@ class Server(object):
         self.host_filter = 'state !=0'
         self.service_filter = 'state !=0 or host.state != 0'
 
+        # Opsview hashtag filter
+        self.hashtag_filter = ''
+
         # Sensu/Uchiwa/??? Datacenter/Site config
         self.monitor_site = 'Site 1'
 

--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5696,6 +5696,8 @@ class Dialog_Server(Dialog):
             self.window.input_lineedit_service_filter: ['op5Monitor'],
             self.window.label_service_filter: ['op5Monitor'],
             self.window.label_host_filter: ['op5Monitor'],
+            self.window.input_lineedit_hashtag_filter: ['Opsview'],
+            self.window.label_hashtag_filter: ['Opsview'],
             self.window.label_monitor_site: ['Sensu'],
             self.window.input_lineedit_monitor_site: ['Sensu'],
             self.window.label_map_to_hostname: ['Prometheus', 'Alertmanager'],

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -245,6 +245,9 @@ class GenericServer(object):
         self.host_filter = 'state !=0'
         self.service_filter = 'state !=0 or host.state != 0'
 
+        # Opsview hashtag filter
+        self.hashtag_filter = ''
+
         # Sensu/Uchiwa/??? Datacenter/Site config
         self.monitor_site = 'Site 1'
 

--- a/Nagstamon/Servers/Opsview.py
+++ b/Nagstamon/Servers/Opsview.py
@@ -202,9 +202,7 @@ class OpsviewServer(GenericServer):
         """
 	        Get status from Opsview Server
         """
-        if self.hashtag_filter == '':
-            keywords = ''
-        else:
+        if self.hashtag_filter != '':
             self.Debug(server=self.get_name(), debug="Raw hashtag filter string: " + self.hashtag_filter)
 
             trimmed_hashtags = re.sub(r'[#|\s]', '', self.hashtag_filter).split(",")
@@ -213,6 +211,8 @@ class OpsviewServer(GenericServer):
 
             keywords = "&keyword=" + "&keyword=".join(list_of_non_empty_hashtags)
             self.Debug(server=self.get_name(), debug="Keyword string" + pprint.pformat(keywords))
+        else:
+            keywords = ''
         # following XXXX to get ALL services in ALL states except OK
         # because we filter them out later
         # the REST API gets all host and service info in one call

--- a/Nagstamon/Servers/Opsview.py
+++ b/Nagstamon/Servers/Opsview.py
@@ -205,7 +205,7 @@ class OpsviewServer(GenericServer):
         if self.hashtag_filter != '':
             self.Debug(server=self.get_name(), debug="Raw hashtag filter string: " + self.hashtag_filter)
 
-            trimmed_hashtags = re.sub(r'[#|\s]', '', self.hashtag_filter).split(",")
+            trimmed_hashtags = re.sub(r'[#\s]', '', self.hashtag_filter).split(",")
             list_of_non_empty_hashtags = [i for i in trimmed_hashtags if i]
             self.Debug(server=self.get_name(), debug="List of trimmed hashtags" + pprint.pformat(list_of_non_empty_hashtags))
 

--- a/Nagstamon/Servers/Opsview.py
+++ b/Nagstamon/Servers/Opsview.py
@@ -23,6 +23,7 @@ import sys
 import urllib.request, urllib.parse, urllib.error
 import copy
 import pprint
+import re
 import json
 
 from datetime import datetime, timedelta
@@ -201,11 +202,26 @@ class OpsviewServer(GenericServer):
         """
 	        Get status from Opsview Server
         """
+        if self.hashtag_filter == '':
+            keywords = ''
+        else:
+            self.Debug(server=self.get_name(), debug="Raw hashtag filter string: " + self.hashtag_filter)
+
+            trimmed_hashtags = re.sub(r'[#|\s]', '', self.hashtag_filter).split(",")
+            list_of_non_empty_hashtags = [i for i in trimmed_hashtags if i]
+            self.Debug(server=self.get_name(), debug="List of trimmed hashtags" + pprint.pformat(list_of_non_empty_hashtags))
+
+            keywords = "&keyword=" + "&keyword=".join(list_of_non_empty_hashtags)
+            self.Debug(server=self.get_name(), debug="Keyword string" + pprint.pformat(keywords))
         # following XXXX to get ALL services in ALL states except OK
         # because we filter them out later
         # the REST API gets all host and service info in one call
         try:
-            result = self.FetchURL(self.monitor_url + "/rest/status/service?state=1&state=2&state=3", giveback="raw")
+            if keywords == '':
+                result = self.FetchURL(self.monitor_url + "/rest/status/service?state=1&state=2&state=3", giveback="raw")
+            else:
+                result = self.FetchURL(self.monitor_url + "/rest/status/service?state=1&state=2&state=3" + keywords, giveback="raw")
+
             data, error, status_code = json.loads(result.result), result.error, result.status_code
 
             # check if any error occured

--- a/Nagstamon/Servers/__init__.py
+++ b/Nagstamon/Servers/__init__.py
@@ -199,6 +199,9 @@ def create_server(server=None):
     new_server.host_filter = server.host_filter
     new_server.service_filter = server.service_filter
 
+    # Opsview hashtag filters
+    new_server.hashtag_filter = server.hashtag_filter
+
     # Zabbix
     new_server.use_description_name_service = server.use_description_name_service
 

--- a/Nagstamon/resources/qui/settings_server.ui
+++ b/Nagstamon/resources/qui/settings_server.ui
@@ -618,6 +618,19 @@
         </property>
        </widget>
       </item>
+      <item row="10" column="1">
+       <widget class="QLabel" name="label_hashtag_filter">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Hashtag filter:</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1" colspan="3">
        <widget class="QCheckBox" name="input_checkbox_ignore_cert">
         <property name="text">
@@ -630,6 +643,13 @@
       </item>
       <item row="10" column="2" colspan="2">
        <widget class="QLineEdit" name="input_lineedit_host_filter">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="2" colspan="2">
+       <widget class="QLineEdit" name="input_lineedit_hashtag_filter">
         <property name="text">
          <string/>
         </property>


### PR DESCRIPTION
- Add a new optional configuration field for Opsview hashtags.
- The configuration field takes a comma-separated list of hashtags.
- This will filter all objects to only display those with the selected tags.