### PR TITLE
Add the can_change_only option for Opsview.

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -941,8 +941,16 @@ class Server(object):
         self.host_filter = 'state !=0'
         self.service_filter = 'state !=0 or host.state != 0'
 
-        # Opsview hashtag filter
+        # For more information about he Opsview options below, see this link:
+        # https://knowledge.opsview.com/reference/api-status-filtering-service-objects
+
+        # The Opsview hashtag filter will filter out any services NOT having the
+        # listed hashtags (previously known as keywords).
         self.hashtag_filter = ''
+        # The Opsview can_change_only option allows a user to show only
+        # services for which the user has permissions to make changes OR set
+        # downtimes.
+        self.can_change_only = False
 
         # Sensu/Uchiwa/??? Datacenter/Site config
         self.monitor_site = 'Site 1'

--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5698,6 +5698,7 @@ class Dialog_Server(Dialog):
             self.window.label_host_filter: ['op5Monitor'],
             self.window.input_lineedit_hashtag_filter: ['Opsview'],
             self.window.label_hashtag_filter: ['Opsview'],
+            self.window.input_checkbox_can_change_only: ['Opsview'],
             self.window.label_monitor_site: ['Sensu'],
             self.window.input_lineedit_monitor_site: ['Sensu'],
             self.window.label_map_to_hostname: ['Prometheus', 'Alertmanager'],

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -249,6 +249,9 @@ class GenericServer(object):
         # Opsview hashtag filter
         self.hashtag_filter = ''
 
+        # Opsview can_change_only option
+        self.can_change_only = False
+
         # Sensu/Uchiwa/??? Datacenter/Site config
         self.monitor_site = 'Site 1'
 

--- a/Nagstamon/Servers/Opsview.py
+++ b/Nagstamon/Servers/Opsview.py
@@ -202,25 +202,42 @@ class OpsviewServer(GenericServer):
         """
 	        Get status from Opsview Server
         """
+        if self.can_change_only:
+            if conf.debug_mode:
+                self.Debug(server=self.get_name(),
+                           debug="Showing only objects that the user can change or put in downtime")
+
+            can_change = '&can_change=true'
+        else:
+            can_change = ''
+
         if self.hashtag_filter != '':
-            self.Debug(server=self.get_name(), debug="Raw hashtag filter string: " + self.hashtag_filter)
+            if conf.debug_mode:
+                self.Debug(server=self.get_name(),
+                           debug="Raw hashtag filter string: " +
+                           self.hashtag_filter)
 
             trimmed_hashtags = re.sub(r'[#\s]', '', self.hashtag_filter).split(",")
             list_of_non_empty_hashtags = [i for i in trimmed_hashtags if i]
-            self.Debug(server=self.get_name(), debug="List of trimmed hashtags" + pprint.pformat(list_of_non_empty_hashtags))
+
+            if conf.debug_mode:
+                self.Debug(server=self.get_name(),
+                           debug="List of trimmed hashtags" +
+                           pprint.pformat(list_of_non_empty_hashtags))
 
             keywords = "&keyword=" + "&keyword=".join(list_of_non_empty_hashtags)
-            self.Debug(server=self.get_name(), debug="Keyword string" + pprint.pformat(keywords))
+
+            if conf.debug_mode:
+                self.Debug(server=self.get_name(),
+                           debug="Keyword string" + pprint.pformat(keywords))
         else:
             keywords = ''
+
         # following XXXX to get ALL services in ALL states except OK
         # because we filter them out later
         # the REST API gets all host and service info in one call
         try:
-            if keywords == '':
-                result = self.FetchURL(self.monitor_url + "/rest/status/service?state=1&state=2&state=3", giveback="raw")
-            else:
-                result = self.FetchURL(self.monitor_url + "/rest/status/service?state=1&state=2&state=3" + keywords, giveback="raw")
+            result = self.FetchURL(self.monitor_url + "/rest/status/service?state=1&state=2&state=3" + can_change + keywords, giveback="raw")
 
             data, error, status_code = json.loads(result.result), result.error, result.status_code
 
@@ -308,7 +325,5 @@ class OpsviewServer(GenericServer):
                        debug='Open service monitor web page ' + service_url)
             webbrowser_open(service_url)
 
-    def open_monitor_webpage(self, host, service):
-        webbrowser_open('%s/monitoring/#!?autoSelectHost=%s' % (self.monitor_url, host))
-
-
+    def open_monitor_webpage(self):
+        webbrowser_open('%s/monitoring/' % (self.monitor_url))

--- a/Nagstamon/Servers/__init__.py
+++ b/Nagstamon/Servers/__init__.py
@@ -199,8 +199,9 @@ def create_server(server=None):
     new_server.host_filter = server.host_filter
     new_server.service_filter = server.service_filter
 
-    # Opsview hashtag filters
+    # Opsview hashtag filter and can_change_only option
     new_server.hashtag_filter = server.hashtag_filter
+    new_server.can_change_only = server.can_change_only
 
     # Zabbix
     new_server.use_description_name_service = server.use_description_name_service

--- a/Nagstamon/resources/qui/settings_server.ui
+++ b/Nagstamon/resources/qui/settings_server.ui
@@ -631,6 +631,13 @@
         </property>
        </widget>
       </item>
+      <item row="11" column="1" colspan="3">
+       <widget class="QCheckBox" name="input_checkbox_can_change_only">
+        <property name="text">
+         <string>Only show services that the user can change or set downtimes on</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1" colspan="3">
        <widget class="QCheckBox" name="input_checkbox_ignore_cert">
         <property name="text">


### PR DESCRIPTION
This commit adds a new checkbox for Opsview servers that will filter out all services that the user cannot either change or set downtimes on.

It also contains some fixes where the `if conf.debug_mode` logic was missing from some Debug calls.

Also, it fixes a bug where clicking the link of the Opsview server address in the 'right click menu' would throw an error and crash the application.