### PR TITLE
register nagstamon version on windows when installing via setup

### DIFF
--- a/build/windows/nagstamon.iss
+++ b/build/windows/nagstamon.iss
@@ -1,7 +1,7 @@
 [Setup]
 AppName=Nagstamon
-AppVerName=Nagstamon {#version}
-AppVersion={#version}
+AppVerName=Nagstamon {#version_is}
+AppVersion={#version_is}
 AppPublisher=Henri Wahl
 DefaultDirName={commonpf}\Nagstamon
 DefaultGroupName=Nagstamon


### PR DESCRIPTION
Registering the correct nagstamon version on windows is needed for handling updates and upgrades e.g. via winget.

Ticket-Nr: 902
Resolves #902 