### PR TITLE
Support reading icinga checks via notification api

### DIFF
--- a/Nagstamon/Config.py
+++ b/Nagstamon/Config.py
@@ -969,6 +969,10 @@ class Server(object):
         self.map_to_unknown = 'unknown'
         self.map_to_ok = 'ok'
 
+        # IcingaDBWebNotificationsServer
+        self.notification_filter = "user.name=*"
+        self.notification_lookback = "30 minutes"
+
 class Action(object):
     """
     class for custom actions, which whill be thrown into one config dictionary like the servers

--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5790,7 +5790,11 @@ class Dialog_Server(Dialog):
             self.window.label_map_to_warning: ['Alertmanager'],
             self.window.input_lineedit_map_to_warning: ['Alertmanager'],
             self.window.label_map_to_critical: ['Alertmanager'],
-            self.window.input_lineedit_map_to_critical: ['Alertmanager']
+            self.window.input_lineedit_map_to_critical: ['Alertmanager'],
+            self.window.input_lineedit_notification_filter: ['IcingaDBWebNotifications'],
+            self.window.label_notification_filter: ['IcingaDBWebNotifications'],
+            self.window.input_lineedit_notification_lookback: ['IcingaDBWebNotifications'],
+            self.window.label_notification_lookback: ['IcingaDBWebNotifications'],
         }
 
         # to be used when selecting authentication method Kerberos

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -258,6 +258,10 @@ class GenericServer(object):
         # Zabbix
         self.use_description_name_service = None
 
+        # IcingaDBWebNotifications
+        self.notification_filter = None
+        self.notification_lookback = None
+
     def init_config(self):
         '''
             set URLs for CGI - they are static and there is no need to set them with every cycle

--- a/Nagstamon/Servers/IcingaDBWeb.py
+++ b/Nagstamon/Servers/IcingaDBWeb.py
@@ -442,15 +442,21 @@ class IcingaDBWebServer(GenericServer):
         #if not info_dict['expire_time']:
         #    info_dict['expire_time'] = None
 
-        self._set_acknowledge(info_dict['host'],
-                              info_dict['service'],
-                              info_dict['author'],
-                              info_dict['comment'],
-                              info_dict['sticky'],
-                              info_dict['notify'],
-                              info_dict['persistent'],
-                              all_services,
-                              info_dict['expire_time'])
+        try:
+            self._set_acknowledge(info_dict['host'],
+                                  info_dict['service'],
+                                  info_dict['author'],
+                                  info_dict['comment'],
+                                  info_dict['sticky'],
+                                  info_dict['notify'],
+                                  info_dict['persistent'],
+                                  all_services,
+                                  info_dict['expire_time'])
+        except:
+            import traceback
+            traceback.print_exc(file=sys.stdout)
+            result, error = self.Error(sys.exc_info())
+            return Result(result=result, error=error)
 
 
     def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent, all_services=None, expire_time=None):

--- a/Nagstamon/Servers/IcingaDBWeb.py
+++ b/Nagstamon/Servers/IcingaDBWeb.py
@@ -60,13 +60,13 @@ class IcingaDBWebServer(GenericServer):
     """
     TYPE = 'IcingaDBWeb'
     MENU_ACTIONS = ['Monitor', 'Recheck', 'Acknowledge', 'Submit check result', 'Downtime']
-    STATES_MAPPING = {'hosts' : {0 : 'UP', 1 : 'DOWN', 2 : 'UNREACHABLE'}, \
+    STATES_MAPPING = {'hosts' : {0 : 'UP', 1 : 'DOWN', 2 : 'UNREACHABLE'},
                      'services' : {0 : 'OK', 1 : 'WARNING', 2 : 'CRITICAL', 3 : 'UNKNOWN'}}
-    STATES_MAPPING_REV = {'hosts' : { 'UP': 0, 'DOWN': 1, 'UNREACHABLE': 2}, \
+    STATES_MAPPING_REV = {'hosts' : { 'UP': 0, 'DOWN': 1, 'UNREACHABLE': 2},
                      'services' : {'OK': 0, 'WARNING': 1, 'CRITICAL': 2, 'UNKNOWN': 3}}
-    BROWSER_URLS = { 'monitor': '$MONITOR-CGI$/dashboard', \
-                    'hosts': '$MONITOR-CGI$/icingadb/hosts', \
-                    'services': '$MONITOR-CGI$/icingadb/services', \
+    BROWSER_URLS = { 'monitor': '$MONITOR-CGI$/dashboard',
+                    'hosts': '$MONITOR-CGI$/icingadb/hosts',
+                    'services': '$MONITOR-CGI$/icingadb/services',
                     'history': '$MONITOR-CGI$/icingadb/history'}
 
 
@@ -120,7 +120,7 @@ class IcingaDBWebServer(GenericServer):
             Get status from Icinga Server - only JSON
         """
         # define CGI URLs for hosts and services
-        if self.cgiurl_hosts == self.cgiurl_services == self.cgiurl_monitoring_health == None:
+        if self.cgiurl_hosts is None and self.cgiurl_services is None and self.cgiurl_monitoring_health is None:
             # services (unknown, warning or critical?)
             self.cgiurl_services = {'hard': self.monitor_cgi_url + '/icingadb/services?service.state.is_problem=y&service.state.in_downtime=n&service.state.state_type=hard&columns=service.state.last_update,service.state.is_reachable&format=json', \
                                     'soft': self.monitor_cgi_url + '/icingadb/services?service.state.is_problem=y&service.state.in_downtime=n&service.state.state_type=soft&columns=service.state.last_update,service.state.is_reachable&format=json'}

--- a/Nagstamon/Servers/IcingaDBWebNotifications.py
+++ b/Nagstamon/Servers/IcingaDBWebNotifications.py
@@ -1,0 +1,217 @@
+# encoding: utf-8
+
+# Nagstamon - Nagios status monitor for your desktop
+# Copyright (C) 2008-2023 Henri Wahl <henri@nagstamon.de> et al.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+# Initial implementation by Marcus Mönnig
+#
+# This Server class connects against IcingaWeb2. The monitor URL in the setup should be
+# something like http://icinga2/icingaweb2
+#
+# Status/TODOs:
+#
+# * The IcingaWeb2 API is not implemented yet, so currently this implementation uses
+#   two HTTP requests per action. The first fetches the HTML, then the form data is extracted and
+#   then a second HTTP POST request is made which actually executed the action.
+#   Once IcingaWeb2 has an API, it's probably the better choice.
+
+
+from Nagstamon.Servers.Generic import GenericServer
+import urllib.parse
+import sys
+import json
+import datetime
+import socket
+
+from bs4 import BeautifulSoup
+from Nagstamon.Objects import (GenericHost,
+                               GenericService,
+                               Result)
+from Nagstamon.Config import (conf,
+                              AppInfo)
+from Nagstamon.Helpers import webbrowser_open
+from Nagstamon.Servers.IcingaDBWeb import IcingaDBWebServer
+
+
+def strfdelta(tdelta, fmt):
+    d = {'days': tdelta.days}
+    d['hours'], rem = divmod(tdelta.seconds, 3600)
+    d['minutes'], d['seconds'] = divmod(rem, 60)
+    return fmt.format(**d)
+
+
+class IcingaDBWebNotificationsServer(IcingaDBWebServer):
+
+    """Read data from IcingaDB in IcingaWeb via the Notification endpoint."""
+
+    TYPE = 'IcingaDBWebNotifications'
+
+    def _get_status(self) -> Result:
+        """Update internal status variables.
+
+        This method updates self.new_host. It will not return any status.
+        It will return an empty Result object on success or a Result with an error on error.
+        """
+        try:
+            return self._update_new_host_content()
+        except:
+            import traceback
+            traceback.print_exc(file=sys.stdout)
+
+            # set checking flag back to False
+            self.isChecking = False
+            result, error = self.Error(sys.exc_info())
+            return Result(result=result, error=error)
+
+    def _update_new_host_content(self) -> Result:
+        """Update self.new_host based on icinga notifications."""
+        notification_url =  "{}/icingadb/notifications?{}&history.event_time>{} ago&format=json".format(
+            self.monitor_cgi_url, self.notification_filter, self.notification_lookback)
+
+        result = self.FetchURL(notification_url, giveback='raw')
+
+        # check if any error occured
+        potential_error = self.check_for_error(result.result, result.error, result.status_code)
+        if potential_error:
+            return potential_error
+
+        self.new_hosts = {}
+
+        notifications = json.loads(result.result)
+
+        for notification in reversed(notifications):
+            if notification["type"] not in ("problem", "recovery"):
+                continue
+            if notification["object_type"] == "host":
+                # host
+                if not self.use_display_name_host:
+                    # according to http://sourceforge.net/p/nagstamon/bugs/83/ it might
+                    # better be name instead of display_name
+                    host_name = notification['host']['name']
+                else:
+                    # https://github.com/HenriWahl/Nagstamon/issues/46 on the other hand has
+                    # problems with that so here we go with extra display_name option
+                    host_name = notification['host']['display_name']
+
+                status_type = notification['host']["state_type"]
+                self.new_hosts[host_name] = GenericHost()
+                self.new_hosts[host_name].name = host_name
+                self.new_hosts[host_name].server = self.name
+                self.new_hosts[host_name].status_type = status_type
+
+                if status_type == 'hard':
+                    self.new_hosts[host_name].status = self.STATES_MAPPING['hosts'][int(notification['host']['state']['hard_state'])]
+                else:
+                    self.new_hosts[host_name].status = self.STATES_MAPPING['hosts'][int(notification['host']['state']['soft_state'])]
+
+                self.new_hosts[host_name].last_check = datetime.datetime.fromtimestamp(int(float(notification['host']['state']['last_update'])))
+                self.new_hosts[host_name].attempt = "{}/{}".format(notification['host']['state']['check_attempt'],notification['host']['max_check_attempts'])
+                self.new_hosts[host_name].status_information = BeautifulSoup(notification['host']['state']['output'].replace('\n', ' ').strip(), 'html.parser').text
+                self.new_hosts[host_name].passiveonly = not int(notification['host'].get('active_checks_enabled') or '0')
+                self.new_hosts[host_name].notifications_disabled = not int(notification['host'].get('notifications_enabled') or '0')
+                self.new_hosts[host_name].flapping = bool(int(notification['host']['state']['is_flapping'] or 0))
+                #s['state']['is_acknowledged'] can be null, 0, 1, or 'sticky'
+                self.new_hosts[host_name].acknowledged = bool(int(notification['host']['state']['is_acknowledged'].replace('sticky', '1') or 0))
+                self.new_hosts[host_name].scheduled_downtime = bool(int(notification['host']['state']['in_downtime'] or 0))
+
+                # extra Icinga properties to solve https://github.com/HenriWahl/Nagstamon/issues/192
+                # acknowledge needs host_description and no display name
+                self.new_hosts[host_name].real_name = notification['host']['name']
+
+                # Icinga only updates the attempts for soft states. When hard state is reached, a flag is set and
+                # attemt is set to 1/x.
+                if status_type == 'hard':
+                    try:
+                        self.new_hosts[host_name].attempt = "{0}/{0}".format(notification['host']['max_check_attempts'])
+                    except Exception:
+                        self.new_hosts[host_name].attempt = "HARD"
+
+                # extra duration needed for calculation
+                if notification['host']['state']['last_state_change'] is not None and notification['host']['state']['last_state_change'] != 0:
+                    duration = datetime.datetime.now() - datetime.datetime.fromtimestamp(int(float(notification['host']['state']['last_state_change'])))
+                    self.new_hosts[host_name].duration = strfdelta(duration,'{days}d {hours}h {minutes}m {seconds}s')
+                else:
+                    self.new_hosts[host_name].duration = 'n/a'
+            elif notification["object_type"] == "service":
+                if not self.use_display_name_host:
+                    # according to http://sourceforge.net/p/nagstamon/bugs/83/ it might
+                    # better be name instead of display_name
+                    host_name = notification['host']['name']
+                else:
+                    # https://github.com/HenriWahl/Nagstamon/issues/46 on the other hand has
+                    # problems with that so here we go with extra display_name option
+                    host_name = notification['host']['display_name']
+
+                # host objects contain service objects
+                if not host_name in self.new_hosts:
+                    self.new_hosts[host_name] = GenericHost()
+                    self.new_hosts[host_name].name = host_name
+                    self.new_hosts[host_name].status = 'UP'
+                    # extra Icinga properties to solve https://github.com/HenriWahl/Nagstamon/issues/192
+                    # acknowledge needs host_description and no display name
+                    self.new_hosts[host_name].real_name = notification['host']['name']
+
+                service_name = notification['service']['display_name']
+
+                status_type = notification['service']["state"]["state_type"]
+
+                # if a service does not exist create its object
+                self.new_hosts[host_name].services[service_name] = GenericService()
+                self.new_hosts[host_name].services[service_name].host = host_name
+                self.new_hosts[host_name].services[service_name].name = service_name
+                self.new_hosts[host_name].services[service_name].server = self.name
+                self.new_hosts[host_name].services[service_name].status_type = status_type
+                if status_type == 'hard':
+                    self.new_hosts[host_name].services[service_name].status = self.STATES_MAPPING['services'][int(notification['service']['state']['hard_state'])]
+                else:
+                    self.new_hosts[host_name].services[service_name].status = self.STATES_MAPPING['services'][int(notification['service']['state']['soft_state'])]
+                self.new_hosts[host_name].services[service_name].last_check = datetime.datetime.fromtimestamp(int(float(notification['service']['state']['last_update'])))
+                self.new_hosts[host_name].services[service_name].status_information = BeautifulSoup(notification['service']['state']['output'].replace('\n', ' ').strip(), 'html.parser').text
+                self.new_hosts[host_name].services[service_name].passiveonly = not int(notification['service'].get('active_checks_enabled') or '0')
+                self.new_hosts[host_name].services[service_name].notifications_disabled = not int(notification['service'].get('notifications_enabled') or '0')
+                self.new_hosts[host_name].services[service_name].flapping = bool(int(notification['service']['state']['is_flapping'] or 0))
+                #s['state']['is_acknowledged'] can be null, 0, 1, or 'sticky'
+                self.new_hosts[host_name].services[service_name].acknowledged = bool(int(notification['service']['state']['is_acknowledged'].replace('sticky', '1') or 0))
+                self.new_hosts[host_name].services[service_name].scheduled_downtime = bool(int(notification['service']['state']['in_downtime'] or 0))
+                self.new_hosts[host_name].services[service_name].unreachable = not bool(int(notification['service']['state']['is_reachable'] or 0))
+
+                if self.new_hosts[host_name].services[service_name].unreachable:
+                    self.new_hosts[host_name].services[service_name].status_information += " (SERVICE UNREACHABLE)"
+
+                # extra Icinga properties to solve https://github.com/HenriWahl/Nagstamon/issues/192
+                # acknowledge needs service_description and no display name
+                self.new_hosts[host_name].services[service_name].real_name = notification['service']['name']
+
+                if status_type == 'hard':
+                    # Icinga only updates the attempts for soft states. When hard state is reached, a flag is set and
+                    # attempt is set to 1/x.
+                    self.new_hosts[host_name].services[service_name].attempt = "{0}/{0}".format(
+                        notification['service']['max_check_attempts'])
+                else:
+                    self.new_hosts[host_name].services[service_name].attempt = "{}/{}".format(
+                        notification['service']['state']['check_attempt'],
+                        notification['service']['max_check_attempts'])
+
+                # extra duration needed for calculation
+                if notification['service']['state']['last_state_change'] is not None and notification['service']['state']['last_state_change'] != 0:
+                    duration = datetime.datetime.now() - datetime.datetime.fromtimestamp(int(float(notification['service']['state']['last_state_change'])))
+                    self.new_hosts[host_name].services[service_name].duration = strfdelta(duration, '{days}d {hours}h {minutes}m {seconds}s')
+                else:
+                    self.new_hosts[host_name].services[service_name].duration = 'n/a'
+
+        # return success
+        return Result()

--- a/Nagstamon/Servers/__init__.py
+++ b/Nagstamon/Servers/__init__.py
@@ -38,6 +38,7 @@ from Nagstamon.Servers.Centreon import CentreonServer
 from Nagstamon.Servers.Icinga import IcingaServer
 from Nagstamon.Servers.IcingaWeb2 import IcingaWeb2Server
 from Nagstamon.Servers.IcingaDBWeb import IcingaDBWebServer
+from Nagstamon.Servers.IcingaDBWebNotifications import IcingaDBWebNotificationsServer
 from Nagstamon.Servers.Multisite import MultisiteServer
 from Nagstamon.Servers.op5Monitor import Op5MonitorServer
 from Nagstamon.Servers.Opsview import OpsviewServer
@@ -190,6 +191,10 @@ def create_server(server=None):
     # IcingaWeb2
     new_server.no_cookie_auth = server.no_cookie_auth
 
+    # IcingaDBWebNotifications
+    new_server.notification_filter = server.notification_filter
+    new_server.notification_lookback = server.notification_lookback
+
     # Checkmk Multisite
     new_server.force_authuser = server.force_authuser
     new_server.checkmk_view_hosts = server.checkmk_view_hosts
@@ -237,6 +242,7 @@ servers_list = [AlertmanagerServer,
                 CentreonServer,
                 IcingaServer,
                 IcingaDBWebServer,
+                IcingaDBWebNotificationsServer,
                 IcingaWeb2Server,
                 LivestatusServer,
                 Monitos3Server,

--- a/Nagstamon/resources/qui/settings_server.ui
+++ b/Nagstamon/resources/qui/settings_server.ui
@@ -443,6 +443,20 @@
         </property>
        </widget>
       </item>
+      <item row="11" column="2" colspan="2">
+       <widget class="QLineEdit" name="input_lineedit_notification_filter">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="2" colspan="2">
+       <widget class="QLineEdit" name="input_lineedit_notification_lookback">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="1">
        <widget class="QLabel" name="label_timeout">
         <property name="text">
@@ -513,6 +527,32 @@
         </property>
         <property name="text">
          <string>Service filter:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <widget class="QLabel" name="label_notification_filter">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Notification filter:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QLabel" name="label_notification_lookback">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Notification lookback horizon:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This API will respect the Icinga notification logic with times, escalations etc. This allows more complex ops setup with one team getting paged first and then an escalation to another team and much more.

PR is on top of two commits from my other two PRs. Let me know if I should remove them from this PR!