### PR TITLE
fix 'NoneType is not subscriptable' error in Icinga2API

### DIFF
--- a/Nagstamon/Servers/Icinga2API.py
+++ b/Nagstamon/Servers/Icinga2API.py
@@ -161,9 +161,12 @@ class Icinga2APIServer(GenericServer):
                     new_service.attempt = "{}/{}".format(
                         int(service['attrs']['check_attempt']),
                         int(service['attrs']['max_check_attempts']))
+                if service['attrs']['last_check_result'] is None:
+                    new_service.status_information = 'UNKNOWN'
+                else:
+                    new_service.status_information = service['attrs']['last_check_result']['output']
                 new_service.last_check = arrow.get(service['attrs']['last_check']).humanize()
                 new_service.duration = arrow.get(service['attrs']['previous_state_change']).humanize()
-                new_service.status_information = service['attrs']['last_check_result']['output']
                 new_service.passiveonly = not(service['attrs']['enable_active_checks'])
                 new_service.notifications_disabled = not(service['attrs']['enable_notifications'])
                 new_service.flapping = service['attrs']['flapping']


### PR DESCRIPTION
When connecting to a certain Icinga instance, it seems that some checks do not have a value for last_check_result. This causes the following error in Nagstamon, with no results displayed:

TypeError: 'NoneType' object is not subscriptable

Enabling debug mode revealed that the error was thrown from the line modified in this commit.

This commit wraps the assignment with a check for None to avoid this error.

fixes #949