### PR TITLE
Stop alertmanager to fetch inhibited alerts

### DIFF
--- a/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
@@ -37,9 +37,9 @@ class AlertmanagerServer(GenericServer):
         'history':  '$MONITOR$/#/alerts'
     }
 
-    API_PATH_ALERTS = "/api/v2/alerts"
+    API_PATH_ALERTS = "/api/v2/alerts?inhibited=false"
     API_PATH_SILENCES = "/api/v2/silences"
-    API_FILTERS = '?filter='
+    API_FILTERS = '&filter='
 
     # vars specific to alertmanager class
     map_to_hostname = ''


### PR DESCRIPTION
Default query for fetching alerts from alertmanager, fetches inhibited alerts also.
By the logic behind the inhibition, there is no need to fetch this alerts.
In this PR I have changed the inhibited query string param to false to filter out inhibited alerts.