### PR TITLE
Nagstamon.Helpers.get_distro: ignore lines missing an equal sign

### DIFF
--- a/Nagstamon/Helpers.py
+++ b/Nagstamon/Helpers.py
@@ -453,8 +453,9 @@ def get_distro():
             os_release_dict = {}
             for line in os_release_file.read_text().splitlines():
                 if not line.startswith('#'):
-                    key, value = line.split('=', 1)
-                    os_release_dict[key] = value.strip('"').strip("'")
+                    try: key, value = line.split('=', 1)
+                    except ValueError: continue
+                    else: os_release_dict[key] = value.strip('"').strip("'")
             # Since CentOS Linux got retired by Red Hat, there are various RHEL derivatives/clones; flow is:
             # CentOS Stream -> Red Hat Enterprise Linux -> (AlmaLinux, EuroLinux, Oracle Linux, Rocky Linux)
             # Goal of this hack is to rule them all as Red Hat Enterprise Linux, the baseline distribution.


### PR DESCRIPTION
When `/etc/os-release` is missing an equal sign (for example, when a line is empty), `get_distro` will throw a `ValueError`. Instead, we can just ignore this line as invalid and continue parsing.