### PR TITLE
Handle null JSON output in Icinga DB Web checks

### DIFF
--- a/Nagstamon/Servers/IcingaDBWeb.py
+++ b/Nagstamon/Servers/IcingaDBWeb.py
@@ -214,7 +214,7 @@ class IcingaDBWebServer(GenericServer):
                             self.new_hosts[host_name].last_check = datetime.datetime.fromisoformat(h['state']['last_update'])
                         
                         self.new_hosts[host_name].attempt = "{}/{}".format(h['state']['check_attempt'],h['max_check_attempts'])
-                        self.new_hosts[host_name].status_information = BeautifulSoup(h['state']['output'].replace('\n', ' ').strip(), 'html.parser').text
+                        self.new_hosts[host_name].status_information = BeautifulSoup(str(h['state']['output']).replace('\n', ' ').strip(), 'html.parser').text
                         self.new_hosts[host_name].passiveonly = not int(h.get('active_checks_enabled') or '0')
                         self.new_hosts[host_name].notifications_disabled = not int(h.get('notifications_enabled') or '0')
                         self.new_hosts[host_name].flapping = bool(int(h['state']['is_flapping'] or 0))
@@ -317,7 +317,7 @@ class IcingaDBWebServer(GenericServer):
                             self.new_hosts[host_name].services[service_name].last_check = datetime.datetime.fromisoformat(s['state']['last_update'])
 
                         self.new_hosts[host_name].services[service_name].attempt = "{}/{}".format(s['state']['check_attempt'],s['max_check_attempts'])
-                        self.new_hosts[host_name].services[service_name].status_information = BeautifulSoup(s['state']['output'].replace('\n', ' ').strip(), 'html.parser').text
+                        self.new_hosts[host_name].services[service_name].status_information = BeautifulSoup(str(s['state']['output']).replace('\n', ' ').strip(), 'html.parser').text
                         self.new_hosts[host_name].services[service_name].passiveonly = not int(s.get('active_checks_enabled') or '0')
                         self.new_hosts[host_name].services[service_name].notifications_disabled = not int(s.get('notifications_enabled') or '0')
                         self.new_hosts[host_name].services[service_name].flapping = bool(int(s['state']['is_flapping'] or 0))


### PR DESCRIPTION
- Fixes issue where a check with no output in Icinga DB Web is marked as null in JSON, resulting in 'none' in code
- Resolves processing error by casting the value to a string

Solves: #996 #997 

## Before
![image](https://github.com/HenriWahl/Nagstamon/assets/5150351/1f4effa3-e57e-43cd-a3f7-61e9e986714e)
## After
Empty output will be displayed as `None` in the status information, instead of raising an error.
![image](https://github.com/HenriWahl/Nagstamon/assets/5150351/b48e04f2-2083-4975-bdad-6049ee28f42c)
