### PR TITLE
Add client-side certificate support

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -5772,7 +5772,12 @@ class Dialog_Server(Dialog):
             self.window.input_checkbox_show_options: [self.window.groupbox_options],
             self.window.input_checkbox_custom_cert_use: [self.window.label_custom_ca_file,
                                                          self.window.input_lineedit_custom_cert_ca_file,
-                                                         self.window.button_choose_custom_cert_ca_file]}
+                                                         self.window.button_choose_custom_cert_ca_file],
+            self.window.input_checkbox_use_client_cert: [self.window.label_client_cert_path,
+                                                         self.window.input_lineedit_client_cert_path,
+                                                         self.window.button_choose_client_cert_path,
+                                                         self.window.label_client_cert_password,
+                                                         self.window.input_lineedit_client_cert_password]}
 
         self.TOGGLE_DEPS_INVERTED = [self.window.input_checkbox_use_proxy_from_os]
 
@@ -5850,8 +5855,12 @@ class Dialog_Server(Dialog):
         self.window.button_choose_custom_cert_ca_file.setText('')
         self.window.button_choose_custom_cert_ca_file.setIcon(
             self.window.button_choose_custom_cert_ca_file.style().standardIcon(QStyle.StandardPixmap.SP_DirIcon))
+        self.window.button_choose_client_cert_path.setText('')
+        self.window.button_choose_client_cert_path.setIcon(
+            self.window.button_choose_custom_cert_ca_file.style().standardIcon(QStyle.StandardPixmap.SP_DirIcon))
         # connect choose custom cert CA file button with file dialog
         self.window.button_choose_custom_cert_ca_file.clicked.connect(self.choose_custom_cert_ca_file)
+        self.window.button_choose_client_cert_path.clicked.connect(self.choose_client_cert_path)
 
         # fill authentication combobox
         self.window.input_combobox_authentication.addItems(['Basic', 'Digest', 'Bearer'])
@@ -6159,6 +6168,20 @@ class Dialog_Server(Dialog):
         # only take filename if QFileDialog gave something useful back
         if file != '':
             self.window.input_lineedit_custom_cert_ca_file.setText(file)
+    
+    @Slot()
+    def choose_client_cert_path(self):
+        """
+            show dialog for selection of client certificate
+        """
+        filter = 'PFX files (*.pfx);;p12 files (*.p12);;All Files (*)'
+        file = dialogs.file_chooser.getOpenFileName(self.window,
+                                                    directory=os.path.expanduser('~'),
+                                                    filter=filter)[0]
+
+        # only take filename if QFileDialog gave something useful back
+        if file != '':
+            self.window.input_lineedit_client_cert_path.setText(file)
 
     @Slot()
     def checkmk_view_hosts_reset(self):

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -31,6 +31,7 @@ from urllib.request import getproxies
 
 from bs4 import BeautifulSoup
 import requests
+from requests_pkcs12 import Pkcs12Adapter
 
 # check ECP authentication support availability
 try:
@@ -164,6 +165,9 @@ class GenericServer(object):
         self.proxy_address = ''
         self.proxy_username = ''
         self.proxy_password = ''
+        self.use_client_cert = False
+        self.client_cert_path = ''
+        self.client_cert_password = ''
         self.auth_type = ''
         self.encoding = None
         self.hosts = dict()
@@ -341,6 +345,10 @@ class GenericServer(object):
 
         # add proxy information
         self.proxify(session)
+
+        # add client certificates
+        if self.use_client_cert is True:
+            session.mount(self.monitor_url, Pkcs12Adapter(pkcs12_filename=self.client_cert_path, pkcs12_password=self.client_cert_password))
 
         return session
 

--- a/Nagstamon/resources/qui/settings_server.ui
+++ b/Nagstamon/resources/qui/settings_server.ui
@@ -585,6 +585,63 @@
         </item>
        </layout>
       </item>
+      <item row="7" column="1" colspan="3">
+       <widget class="QCheckBox" name="input_checkbox_use_client_cert">
+        <property name="text">
+         <string>Use client side certificate</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLabel" name="label_client_cert_path">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Cert Path (PKCS12):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLabel" name="label_client_cert_password">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Cert Password:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLineEdit" name="input_lineedit_client_cert_path"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_choose_client_cert_path">
+          <property name="text">
+           <string>Choose file...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="9" column="2">
+       <widget class="QLineEdit" name="input_lineedit_client_cert_password">
+        <property name="text">
+         <string>1234567890</string>
+        </property>
+        <property name="echoMode">
+         <enum>QLineEdit::Password</enum>
+        </property>
+       </widget>
+      </item>
       <item row="36" column="2" colspan="2">
        <widget class="QLineEdit" name="input_lineedit_disabled_backends">
         <property name="text">
@@ -810,6 +867,10 @@
   <tabstop>button_choose_custom_cert_ca_file</tabstop>
   <tabstop>input_combobox_authentication</tabstop>
   <tabstop>input_spinbox_timeout</tabstop>
+  <tabstop>input_checkbox_use_client_cert</tabstop>
+  <tabstop>input_lineedit_client_cert_path</tabstop>
+  <tabstop>button_choose_client_cert_path</tabstop>
+  <tabstop>input_lineedit_client_cert_password</tabstop>
   <tabstop>input_checkbox_use_autologin</tabstop>
   <tabstop>input_lineedit_monitor_site</tabstop>
   <tabstop>input_lineedit_autologin_key</tabstop>

--- a/build/requirements/linux.txt
+++ b/build/requirements/linux.txt
@@ -11,4 +11,5 @@ python-dateutil
 requests
 requests-kerberos
 requests-ecp
+requests-pkcs12
 setuptools

--- a/build/requirements/macos.txt
+++ b/build/requirements/macos.txt
@@ -11,6 +11,7 @@ pysocks
 python-dateutil
 requests
 requests-ecp
+requests-pkcs12
 # gssapi instead kerberos
 requests-gssapi
 setuptools

--- a/build/requirements/windows.txt
+++ b/build/requirements/windows.txt
@@ -14,6 +14,7 @@ pysocks
 python-dateutil
 requests
 requests-ecp
+requests-pkcs12
 # maybe requests-gssapi might become usable with https://github.com/pythongssapi/python-gssapi/issues/244#issuecomment-827404287
 requests-kerberos
 setuptools


### PR DESCRIPTION
Add support for client-side certificates to nagstamon. I've only tested with nagios as I don't have access to others.

I've never used QT before and the UI side of this is not perfect - if you untick the option to use a client certificate then the form does not shrink back down as it should.

HenriWahl/Nagstamon#872