### PR TITLE
Fix Zabbix 6.4 auth Parameter

### DIFF
--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -135,17 +135,6 @@ class ZabbixServer(GenericServer):
         services_in_maintenance = set()
 
         try:
-            api_version = int(''.join(self.zapi.api_version().split('.')[:-1])) # Make API Version smaller
-        except ZabbixAPIException:
-            # FIXME Is there a cleaner way to handle this? I just borrowed
-            # this code from 80 lines ahead. -- AGV
-            # set checking flag back to False
-            self.isChecking = False
-            result, error = self.Error(sys.exc_info())
-            print(sys.exc_info())
-            return Result(result=result, error=error)
-
-        try:
             now_ts = int(datetime.datetime.utcnow().timestamp())
             # only the maintenance object knows about services "in downtime"
             maintenances = self.zapi.maintenance.get({

--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -205,24 +205,43 @@ class ZabbixServer(GenericServer):
             # Create Hostids for shorten Query
             try:
                 hosts = []
-                hostids = []
-                # get just involved Hosts.
-                for service in services:
-                    for host in service["hosts"]:
-                        hostids.append(host["hostid"])
+                if self.zapi.api_version > '5.4':  # For Version 5.4 and higher
+                    # Some performance improvement for 5.4
+                    hostids = []
+                    # get just involved Hosts.
+                    for service in services:
+                        for host in service["hosts"]:
+                            hostids.append(host["hostid"])
 
-                try:
-                    hosts = self.zapi.host.get({"output": ["hostid", "host", "name", "status", "available",
-                                                           "maintenance_status", "maintenance_from"],
-                                                "hostids": hostids,
-                                                "selectInterfaces": ["ip"],
-                                                "filter": {}
-                                                })
-                except (ZabbixError, ZabbixAPIException, APITimeout, Already_Exists):
-                    # set checking flag back to False
-                    self.isChecking = False
-                    result, error = self.Error(sys.exc_info())
-                    return Result(result=result, error=error)
+                    try:
+                        hosts = self.zapi.host.get({"output": ["hostid", "host", "name", "status", "available",
+                                                               "maintenance_status", "maintenance_from"],
+                                                    "hostids": hostids,
+                                                    "selectInterfaces": ["ip"],
+                                                    "filter": {}
+                                                    })
+                    except (ZabbixError, ZabbixAPIException, APITimeout, Already_Exists):
+                        # set checking flag back to False
+                        self.isChecking = False
+                        result, error = self.Error(sys.exc_info())
+                        return Result(result=result, error=error)
+                else:
+                    try:
+                        # TODO: This Query can be removed when Zabbix Version 4 Support is dropped.
+                        hosts = self.zapi.host.get({"output": ["hostid", "host", "name", "status", "available",
+                                                               "error", "errors_from", # dropped in Version 5.4
+                                                               "snmp_available", "snmp_error", "snmp_errors_from", # dropped in Version 5.4
+                                                               "ipmi_available", "ipmi_error", "ipmi_errors_from", # dropped in Version 5.4
+                                                               "jmx_available", "jmx_error", "jmx_errors_from", # dropped in Version 5.4
+                                                               "maintenance_status", "maintenance_from"],
+                                                    "selectInterfaces": ["ip"],
+                                                    "filter": {}
+                                                    })
+                    except (ZabbixError, ZabbixAPIException, APITimeout, Already_Exists):
+                        # set checking flag back to False
+                        self.isChecking = False
+                        result, error = self.Error(sys.exc_info())
+                        return Result(result=result, error=error)
                 # get All Hosts.
                 # 1. Store data in cache (to be used by events)
                 # 2. We store as faulty two kinds of hosts incidences:

--- a/Nagstamon/thirdparty/zabbix_api.py
+++ b/Nagstamon/thirdparty/zabbix_api.py
@@ -179,10 +179,10 @@ class ZabbixAPI(object):
         obj = {'jsonrpc': '2.0',
                'method': method,
                'params': params,
-               'auth': self.auth,
+               'auth': self.auth,  # deprecated in 6.4
                'id': self.id
                }
-        if not auth:
+        if not auth or self.api_version > '6.4':
             del obj['auth']
 
         self.debug(logging.DEBUG, "json_obj: " + str(obj))
@@ -204,7 +204,7 @@ class ZabbixAPI(object):
             raise ZabbixAPIException("No authentication information available.")
 
         # check version to use the correct keyword for username which changed since 6.4
-        if self.api_version() < '6.4':
+        if self.api_version < '6.4':
             username_keyword = 'user'
         else:
             username_keyword = 'username'
@@ -233,6 +233,8 @@ class ZabbixAPI(object):
         headers = {'Content-Type': 'application/json-rpc',
                    'User-Agent': 'python/zabbix_api'}
 
+        if self.api_version > '6.4':
+            headers['Authorization'] = 'Bearer ' + self.auth
         if self.httpuser:
             self.debug(logging.INFO, "HTTP Auth enabled")
             auth = 'Basic ' + string.strip(base64.encodestring(self.httpuser + ':' + self.httppasswd))

--- a/Nagstamon/thirdparty/zabbix_api.py
+++ b/Nagstamon/thirdparty/zabbix_api.py
@@ -119,6 +119,7 @@ class ZabbixAPI(object):
     httppasswd = None
     timeout = 10
     validate_certs = None
+    api_version = '0.0'
     # sub-class instances.
     # Constructor Params:
     # server: Server to connect to
@@ -149,6 +150,8 @@ class ZabbixAPI(object):
         self.r_query = deque([], maxlen=r_query_len)
         self.validate_certs = validate_certs
         self.debug(logging.INFO, "url: " + self.url)
+        self.api_version = self.get_api_version()
+        self.debug(logging.INFO, "Zabbix API version: " + self.api_version)
 
     def _setuplogging(self):
         self.logger = logging.getLogger("zabbix_api.%s" % self.__class__.__name__)
@@ -301,7 +304,7 @@ class ZabbixAPI(object):
             return True
         return False
 
-    def api_version(self, **options):
+    def get_api_version(self, **options):
         # kicked out check auth to be able to check version before being logged in to use the correct username keyword
         obj = self.do_request(self.json_obj('apiinfo.version', options, auth=False))
         return obj['result']


### PR DESCRIPTION
Fix for Zabbix API: 
Remove deprecated auth parameter
Add new Authorization header
Move Version handling to Server class
