### PR TITLE
Fix downtime and recheck functions for CheckMK 2.3

### DIFF
--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -103,6 +103,7 @@ class MultisiteServer(GenericServer):
               'api_svcprob_act': self.monitor_url + '/view.py?_transid=-1&_do_actions=yes&_do_confirm=Yes!&view_name=svcproblems&filled_in=actions&lang=',
               'human_events':    self.monitor_url + '/index.py?%s' %
                                                    urllib.parse.urlencode({'start_url': 'view.py?view_name=events'}),
+              'recheck':         self.monitor_url + '/ajax_reschedule.py?_ajaxid=0',
               'omd_version':         self.monitor_url + '/api/1.0/version',
               'transid':         self.monitor_url + '/view.py?actions=yes&filled_in=actions&host=$HOST$&service=$SERVICE$&view_name=service'
             }
@@ -546,6 +547,21 @@ class MultisiteServer(GenericServer):
             '_resched_pread':  '0'
         }
         self._action(self.hosts[host].site, host, service, p)
+
+
+    def _omd_set_recheck(self, host, service):
+        """
+           _set_recheck function for Checkmk version 2.3+
+        """
+        csrf_token = self._get_csrf_token(host, service)
+        data = {
+            "site": self.hosts[host].site,
+            "host": host,
+            "service": service,
+            "wait_svc": service,
+            "csrf_token": csrf_token,
+        }
+        self.FetchURL(self.urls["recheck"], cgi_data=data)
 
 
     def recheck_all(self):

--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -120,6 +120,12 @@ class MultisiteServer(GenericServer):
                 'PEND':    'PENDING',
             }
 
+        # Function overrides for Checkmk 2.3+
+        version = self._omd_get_version()
+        if version >= [2, 3]:
+            self._set_downtime = self._omd_set_downtime
+            self._set_recheck = self._omd_set_recheck
+
         if self.CookieAuth and not self.refresh_authentication:
             # get cookie to access Checkmk web interface
             if 'cookies' in dir(self.session):

--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -103,6 +103,7 @@ class MultisiteServer(GenericServer):
               'api_svcprob_act': self.monitor_url + '/view.py?_transid=-1&_do_actions=yes&_do_confirm=Yes!&view_name=svcproblems&filled_in=actions&lang=',
               'human_events':    self.monitor_url + '/index.py?%s' %
                                                    urllib.parse.urlencode({'start_url': 'view.py?view_name=events'}),
+              'omd_version':         self.monitor_url + '/api/1.0/version',
               'transid':         self.monitor_url + '/view.py?actions=yes&filled_in=actions&host=$HOST$&service=$SERVICE$&view_name=service'
             }
 
@@ -582,3 +583,15 @@ class MultisiteServer(GenericServer):
             service = "PING"
         csrf_token = self.FetchURL(self.urls["transid"].replace("$HOST$", host).replace("$SERVICE$", service.replace(" ", "+")), "obj").result.find(attrs={"name": "csrf_token"})["value"]
         return csrf_token
+
+
+    def _omd_get_version(self):
+        """
+           get version of OMD Checkmk as [major_version, minor_version]
+        """
+        try:
+            version = [int(v) for v in self.session.get(self.urls["omd_version"]).json()["versions"]["checkmk"].split(".")[:2]]
+        # If /version api is not supported, return the lowest non-negative pair
+        except:
+            version = [0, 0]
+        return version

--- a/Nagstamon/Servers/Multisite.py
+++ b/Nagstamon/Servers/Multisite.py
@@ -571,3 +571,14 @@ class MultisiteServer(GenericServer):
         transid = self.FetchURL(self.urls['transid'].replace('$HOST$', host).replace('$SERVICE$', service.replace(' ', '+')),
                                 'obj').result.find(attrs={'name' : '_transid'})['value']
         return transid
+
+
+    def _get_csrf_token(self, host, service):
+        """
+           get csrf token for the session
+        """
+        # since Checkmk 2.0 it seems to be a problem if service is empty so fill it with a definitively existing one
+        if not service:
+            service = "PING"
+        csrf_token = self.FetchURL(self.urls["transid"].replace("$HOST$", host).replace("$SERVICE$", service.replace(" ", "+")), "obj").result.find(attrs={"name": "csrf_token"})["value"]
+        return csrf_token


### PR DESCRIPTION
Since the upgrade from version 2.2 to 2.3 of CheckMK, the downtime and recheck commands stopped working from Nagstamon (acknowledge is still working). It seems like CheckMK is trying to deprecate the legacy API in favor of the new REST API.

We haven't been able to pin-point the _exact_ change that caused this incompatibility. However, we were able to find evidences that CheckMK is trying to drop the legacy API in favor of the REST API. Below are some examples of changes that force users to use the REST API:
* [Werk #16689: Decommission legacy check API](https://checkmk.com/werk/16689)
> Commandline call plugins for special agents and active checks in this folder will still work, but we provide a new API for those as well now (see [Werk #16259](https://checkmk.com/werk/16259)). They will stop working in Checkmk 2.4.
* [Werk #13640: Deprecation of Web API](https://checkmk.com/werk/13640)
> We recommend migrating all existing scripts that use the Web API to the REST API as soon as possible to catch issues early before you move to CheckMK 2.2.

Changes made in this PR have been tested against:
* Legacy CheckMK `1.2.6p12` on Bionic
* OMD CheckMK `2.2.0p26.cre` on Focal 
* OMD CheckMK `2.3.0p3.cre` on Jammy

Contact: jkim@xelerance.com