### PR TITLE
Handle flexible downtimes for Zabbix

### DIFF
--- a/Nagstamon/Servers/Zabbix.py
+++ b/Nagstamon/Servers/Zabbix.py
@@ -543,11 +543,15 @@ class ZabbixServer(GenericServer):
 
         hostids = [self.hosts[hostname].hostid]
 
-        date = datetime.datetime.strptime(start_time, "%Y-%m-%d %H:%M")
-        stime = int(time.mktime(date.timetuple()))
+        if fixed == 1:
+            start_date = datetime.datetime.strptime(start_time, "%Y-%m-%d %H:%M")
+            end_date = datetime.datetime.strptime(end_time, "%Y-%m-%d %H:%M")
+        else:
+            start_date = datetime.datetime.now()
+            end_date = start_date + datetime.timedelta(hours=hours, minutes=minutes)
 
-        date = datetime.datetime.strptime(end_time, "%Y-%m-%d %H:%M")
-        etime = int(time.mktime(date.timetuple()))
+        stime = int(time.mktime(start_date.timetuple()))
+        etime = int(time.mktime(end_date.timetuple()))
 
         if conf.debug_mode is True:
             self.debug(server=self.get_name(),


### PR DESCRIPTION
Hi Henri,

Long-time users and fans of Nagstamon here at my employer, great tool!

We've recently switched to using Zabbix as our main monitoring system and have noticed some areas in the Zabbix server implementation that could benefit from improvements.

Hope you are open to adding some of our improvements into the official Nagstamon, will be creating more PRs if you agree in the near future.

As for this PR, it adds support for "flexible downtimes" to the Zabbix server.