### PR TITLE
Update nagstamon.iss

### DIFF
--- a/build/windows/nagstamon.iss
+++ b/build/windows/nagstamon.iss
@@ -23,7 +23,7 @@ Compression=lzma
 SolidCompression=true
 SourceDir={#source}
 ArchitecturesAllowed={#archs_allowed}
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesInstallIn64BitMode=x64compatible
 CloseApplications=no
 WizardStyle=modern
 [Icons]


### PR DESCRIPTION
While building I recieved following warning:

Warning: Architecture identifier "x64" is deprecated. Substituting "x64os", but note that "x64compatible" is preferred in most cases. See the "Architecture Identifiers" topic in help file for more information.

https://jrsoftware.org/ishelp/index.php?topic=archidentifiers

After changing this line, the build runs without any problem