### PR TITLE
fix(alertmanager): Continue loop when severity is None

### DIFF
--- a/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
@@ -224,7 +224,7 @@ class AlertmanagerServer(GenericServer):
             for alert in data:
                 alert_data = self._process_alert(alert)
                 if not alert_data:
-                    break
+                    continue
 
                 service = AlertmanagerService()
                 service.host = alert_data['host']


### PR DESCRIPTION
Hello,

When the alert is on severity: None, the next alerts are not displayed. It's probably due because the loop is exited with a break, but probably should continue to the next items

I propose this change from break to continue so the loops can iterate on all items