### PR TITLE
Alertmanager: Multiple alerts per host,service pair

### DIFF
--- a/Nagstamon/QUI/__init__.py
+++ b/Nagstamon/QUI/__init__.py
@@ -4347,8 +4347,9 @@ class TreeView(QTreeView):
                         for service in status[1]:
                             if conf.debug_mode:
                                 self.server.debug(server=self.server.name,
-                                                  debug='Rechecking service {0} on host {1}'.format(service.name,
-                                                                                                    service.host))
+                                                  debug='Rechecking service {0} on host {1}'.format(
+                                                        service.get_service_name(),
+                                                        service.host))
                             # call server recheck method
                             self.server.set_recheck({'host': service.host, 'service': service.name})
                     del (nagitems_filtered, status)

--- a/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/Servers/Alertmanager/alertmanagerserver.py
@@ -228,7 +228,8 @@ class AlertmanagerServer(GenericServer):
 
                 service = AlertmanagerService()
                 service.host = alert_data['host']
-                service.name = alert_data['name']
+                service.name = alert_data['fingerprint']
+                service.display_name = alert_data['name']
                 service.server = alert_data['server']
                 service.status = alert_data['status']
                 service.labels = alert_data['labels']
@@ -248,12 +249,6 @@ class AlertmanagerServer(GenericServer):
                     self.new_hosts[service.host].name = str(service.host)
                     self.new_hosts[service.host].server = self.name
                 self.new_hosts[service.host].services[service.name] = service
-                if service.name not in self.new_hosts[service.host].services:
-                    self.new_hosts[service.host].services[service.name] = service
-                else:
-                    # Compare the labels if they match do *not* create a new "instance" of alert
-                    if not service.labels == self.new_hosts[service.host].services[service.name].labels:
-                        self.new_hosts[service.host].services[service.name + service.fingerprint[0:4]] = service
 
         except Exception as the_exception:
             # set checking flag back to False

--- a/Nagstamon/Servers/Alertmanager/alertmanagerservice.py
+++ b/Nagstamon/Servers/Alertmanager/alertmanagerservice.py
@@ -4,5 +4,14 @@ class AlertmanagerService(GenericService):
     """
     add alertmanager specific service property to generic service class
     """
-    service_object_id = ""
+    fingerprint = ""
     labels = {}
+
+    def get_service_name(self):
+        return self.display_name
+
+    def get_hash(self):
+        """
+            return hash for event history tracking
+        """
+        return " ".join((self.server, self.site, self.host, self.name, self.status, self.fingerprint))

--- a/Nagstamon/Servers/Generic.py
+++ b/Nagstamon/Servers/Generic.py
@@ -1086,7 +1086,7 @@ class GenericServer(object):
 
             for service in host.services.values():
                 # add service name for sorting
-                service.service = service.name
+                service.service = service.get_service_name()
                 # Some generic filtering
                 if service.acknowledged is True and conf.filter_acknowledged_hosts_services is True:
                     if conf.debug_mode:


### PR DESCRIPTION
This is an attempt to fix #723 with the second approach described in comment https://github.com/HenriWahl/Nagstamon/issues/723#issuecomment-847265705.

Basically, I try to handle multiple alertmanager-alerts by using their alertmanager-fingerprint as 'service name' internally, but the actual alertmanager-alert-name as display name.

What do you think?