### PR TITLE
fix IcingaWeb2.py get_status uri

### DIFF
--- a/Nagstamon/Servers/IcingaWeb2.py
+++ b/Nagstamon/Servers/IcingaWeb2.py
@@ -122,11 +122,11 @@ class IcingaWeb2Server(GenericServer):
         # define CGI URLs for hosts and services
         if self.cgiurl_hosts == self.cgiurl_services == self.cgiurl_monitoring_health == None:
             # services (unknown, warning or critical?)
-            self.cgiurl_services = {'hard': self.monitor_cgi_url + '/monitoring/list/services?service_state>0&service_state<=3&service_state_type=1&addColumns=service_last_check,service_is_reachable&format=json', \
-                                    'soft': self.monitor_cgi_url + '/monitoring/list/services?service_state>0&service_state<=3&service_state_type=0&addColumns=service_last_check,service_is_reachable&format=json'}
+            self.cgiurl_services = {'hard': self.monitor_cgi_url + '/monitoring/list/services?service_state>=0&service_state<=3&service_state_type=1&addColumns=service_last_check,service_is_reachable&format=json', \
+                                    'soft': self.monitor_cgi_url + '/monitoring/list/services?service_state>=0&service_state<=3&service_state_type=0&addColumns=service_last_check,service_is_reachable&format=json'}
             # hosts (up or down or unreachable)
-            self.cgiurl_hosts = {'hard': self.monitor_cgi_url + '/monitoring/list/hosts?host_state>0&host_state<=2&host_state_type=1&addColumns=host_last_check&format=json', \
-                                 'soft': self.monitor_cgi_url + '/monitoring/list/hosts?host_state>0&host_state<=2&host_state_type=0&addColumns=host_last_check&format=json'}
+            self.cgiurl_hosts = {'hard': self.monitor_cgi_url + '/monitoring/list/hosts?host_state>=0&host_state<=2&host_state_type=1&addColumns=host_last_check&format=json', \
+                                 'soft': self.monitor_cgi_url + '/monitoring/list/hosts?host_state>=0&host_state<=2&host_state_type=0&addColumns=host_last_check&format=json'}
             # monitoring health
             self.cgiurl_monitoring_health = self.monitor_cgi_url + '/monitoring/health/info?format=json'
 


### PR DESCRIPTION
Using Nagstamon with my icingaweb2 server behind a WAP, I've just noticed that the check URIs are missing the “=” for the check URIs in get_status...

So here's a little fix to correct the problem.