### PR TITLE
Add OIDC authentication support for IcingaDB Web

### DIFF
--- a/Nagstamon/config.py
+++ b/Nagstamon/config.py
@@ -120,7 +120,8 @@ CONFIG_STRINGS = ['custom_browser',
                   'autologin_key',
                   'custom_cert_ca_file',
                   'idp_ecp_endpoint',
-                  'monitor_site'
+                  'monitor_site',
+                  'oidc_client_id'
                   ]
 
 
@@ -1064,6 +1065,10 @@ class Server:
         self.custom_cert_ca_file = ''
 
         self.idp_ecp_endpoint = 'https://idp/idp/profile/SAML2/SOAP/ECP'
+
+        # OIDC authentication (auto-discovered via server's OIDC discovery endpoint)
+        self.oidc_client_id = 'nagstamon'
+        self.oidc_redirect_port = 12345
 
         # special FX
         # Centreon autologin

--- a/Nagstamon/cookies.py
+++ b/Nagstamon/cookies.py
@@ -274,3 +274,119 @@ def delete_cookie(server_name: str, cookie_name: Optional[str] = None, domain: O
     connection.commit()
     connection.close()
     return deleted
+
+
+def _init_oidc_table():
+    """
+    initialize OIDC tokens table in the same SQLite database
+    """
+    init_db()
+    connection = sqlite3.connect(COOKIE_DB_FILE_PATH)
+    cursor = connection.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS oidc_tokens
+        (
+            server TEXT PRIMARY KEY,
+            access_token TEXT,
+            refresh_token TEXT,
+            id_token TEXT,
+            expires_at REAL,
+            token_endpoint TEXT,
+            authorization_endpoint TEXT,
+            client_id TEXT,
+            encrypted INTEGER
+        )
+    ''')
+    connection.commit()
+    connection.close()
+
+
+def save_oidc_tokens(server_name, token_data):
+    """
+    Save OIDC tokens for a server.
+    token_data: dict with keys access_token, refresh_token, id_token, expires_at,
+                token_endpoint, authorization_endpoint, client_id
+    """
+    _init_oidc_table()
+    connection = sqlite3.connect(COOKIE_DB_FILE_PATH)
+    cursor = connection.cursor()
+
+    refresh_token = token_data.get('refresh_token', '')
+    encrypted = 0
+
+    if encrypt_cookie and refresh_token:
+        encryption_key = get_encryption_key()
+        fernet = Fernet(encryption_key)
+        refresh_token = fernet.encrypt(refresh_token.encode()).decode()
+        encrypted = 1
+
+    cursor.execute('''
+        INSERT OR REPLACE INTO oidc_tokens
+        (server, access_token, refresh_token, id_token, expires_at,
+         token_endpoint, authorization_endpoint, client_id, encrypted)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ''', (
+        server_name,
+        token_data.get('access_token', ''),
+        refresh_token,
+        token_data.get('id_token', ''),
+        token_data.get('expires_at', 0),
+        token_data.get('token_endpoint', ''),
+        token_data.get('authorization_endpoint', ''),
+        token_data.get('client_id', ''),
+        encrypted,
+    ))
+    connection.commit()
+    connection.close()
+
+
+def load_oidc_tokens(server_name):
+    """
+    Load OIDC tokens for a server.
+    Returns dict or None if not found.
+    """
+    _init_oidc_table()
+    connection = sqlite3.connect(COOKIE_DB_FILE_PATH)
+    cursor = connection.cursor()
+    cursor.execute('''
+        SELECT access_token, refresh_token, id_token, expires_at,
+               token_endpoint, authorization_endpoint, client_id, encrypted
+        FROM oidc_tokens WHERE server = ?
+    ''', (server_name,))
+    row = cursor.fetchone()
+    connection.close()
+
+    if row is None:
+        return None
+
+    refresh_token = row[1]
+    encrypted = bool(row[7])
+    if encrypted and refresh_token:
+        encryption_key = get_encryption_key()
+        fernet = Fernet(encryption_key)
+        try:
+            refresh_token = fernet.decrypt(refresh_token.encode()).decode()
+        except InvalidToken:
+            refresh_token = ''
+
+    return {
+        'access_token': row[0],
+        'refresh_token': refresh_token,
+        'id_token': row[2],
+        'expires_at': row[3],
+        'token_endpoint': row[4],
+        'authorization_endpoint': row[5],
+        'client_id': row[6],
+    }
+
+
+def delete_oidc_tokens(server_name):
+    """
+    Delete OIDC tokens for a server.
+    """
+    _init_oidc_table()
+    connection = sqlite3.connect(COOKIE_DB_FILE_PATH)
+    cursor = connection.cursor()
+    cursor.execute('DELETE FROM oidc_tokens WHERE server = ?', (server_name,))
+    connection.commit()
+    connection.close()

--- a/Nagstamon/qui/dialogs/server.py
+++ b/Nagstamon/qui/dialogs/server.py
@@ -18,10 +18,11 @@
 from copy import deepcopy
 from functools import wraps
 import os
+import threading
 from urllib.parse import quote
 
 from Nagstamon.config import conf, CONFIG_STRINGS, BOOLPOOL, Server
-from Nagstamon.cookies import delete_cookie
+from Nagstamon.cookies import delete_cookie, save_oidc_tokens
 from Nagstamon.qui.globals import (ecp_available,
                                    kerberos_available)
 from Nagstamon.qui.qt import (QFileDialog,
@@ -34,6 +35,11 @@ from Nagstamon.qui.dialogs.dialog import Dialog
 from Nagstamon.servers import (create_server,
                                servers,
                                SERVER_TYPES)
+from Nagstamon.thirdparty.oidc_auth import (
+    discover_oidc_from_icingaweb2,
+    OIDCAuthenticator,
+    OIDCError,
+)
 
 
 class DialogServer(Dialog):
@@ -55,6 +61,10 @@ class DialogServer(Dialog):
 
     # signal to emit when web cookies should be deleted for a server
     delete_web_cookies = Signal(str, QWidget)
+
+    # signals for thread-safe OIDC UI updates from background thread
+    _oidc_status_update = Signal(str)
+    _oidc_auth_finished = Signal()
 
     def __init__(self):
         Dialog.__init__(self, 'settings_server')
@@ -151,6 +161,16 @@ class DialogServer(Dialog):
             self.window.label_idp_ecp_endpoint,
             self.window.input_lineedit_idp_ecp_endpoint]
 
+        self.AUTHENTICATION_OIDC_WIDGETS = [
+            self.window.button_oidc_authenticate,
+            self.window.label_oidc_status]
+
+        self.AUTHENTICATION_OIDC_ADVANCED_WIDGETS = [
+            self.window.label_oidc_client_id,
+            self.window.input_lineedit_oidc_client_id,
+            self.window.label_oidc_redirect_port,
+            self.window.input_spinbox_oidc_redirect_port]
+
         # custom CA is not possible with authentification method Web due to the underlying Qt WebEngine aka Chromium
         self.CUSTOM_CERT_CA_WIDGETS = [ self.window.input_checkbox_custom_cert_use ]
 
@@ -176,6 +196,7 @@ class DialogServer(Dialog):
         # because otherwise encryption key cannot be stored securely
         if conf.is_keyring_available():
             combobox_authentication_items.append('Web')
+        combobox_authentication_items.append('OIDC')
         # sort items
         self.window.input_combobox_authentication.addItems(sorted(combobox_authentication_items))
 
@@ -190,6 +211,11 @@ class DialogServer(Dialog):
         self.window.button_checkmk_view_services_reset.clicked.connect(self.checkmk_view_services_reset)
 
         self.window.button_delete_web_cookies.clicked.connect(self.on_delete_web_cookies)
+
+        # OIDC authenticate button
+        self.window.button_oidc_authenticate.clicked.connect(self.on_oidc_authenticate)
+        self._oidc_status_update.connect(self.window.label_oidc_status.setText)
+        self._oidc_auth_finished.connect(lambda: self.window.button_oidc_authenticate.setEnabled(True))
 
         # mode needed for evaluate dialog after ok button pressed - defaults to 'new'
         self.mode = 'new'
@@ -209,14 +235,17 @@ class DialogServer(Dialog):
         """
         when authentication is changed to Kerberos then disable username/password as they are now useless
         """
-        if self.window.input_combobox_authentication.currentText() == 'Kerberos':
+        auth_type = self.window.input_combobox_authentication.currentText()
+
+        # Hide username/password for auth types that don't need them
+        if auth_type in ('Kerberos', 'Web', 'OIDC'):
             for widget in self.AUTHENTICATION_WIDGETS:
                 widget.hide()
         else:
             for widget in self.AUTHENTICATION_WIDGETS:
                 widget.show()
 
-        if self.window.input_combobox_authentication.currentText() == 'ECP':
+        if auth_type == 'ECP':
             for widget in self.AUTHENTICATION_ECP_WIDGETS:
                 widget.show()
         else:
@@ -224,7 +253,7 @@ class DialogServer(Dialog):
                 widget.hide()
 
         # change credential input for bearer auth
-        if self.window.input_combobox_authentication.currentText() == 'Bearer':
+        if auth_type == 'Bearer':
             for widget in self.AUTHENTICATION_BEARER_WIDGETS:
                 widget.hide()
                 self.window.label_password.setText('Token')
@@ -233,15 +262,27 @@ class DialogServer(Dialog):
                 widget.show()
                 self.window.label_password.setText('Password')
 
-        # no need for username + password when using Web authentication
-        if self.window.input_combobox_authentication.currentText() == 'Web':
-            for widget in self.AUTHENTICATION_WIDGETS + self.CUSTOM_CERT_CA_WIDGETS:
+        # Web authentication: hide custom cert, show delete cookies button
+        if auth_type == 'Web':
+            for widget in self.CUSTOM_CERT_CA_WIDGETS:
                 widget.hide()
             self.window.button_delete_web_cookies.show()
-        else:
-            for widget in self.AUTHENTICATION_WIDGETS + self.CUSTOM_CERT_CA_WIDGETS:
+        elif auth_type == 'OIDC':
+            for widget in self.CUSTOM_CERT_CA_WIDGETS:
                 widget.show()
             self.window.button_delete_web_cookies.hide()
+        else:
+            for widget in self.CUSTOM_CERT_CA_WIDGETS:
+                widget.show()
+            self.window.button_delete_web_cookies.hide()
+
+        # OIDC widgets visibility
+        if auth_type == 'OIDC':
+            for widget in self.AUTHENTICATION_OIDC_WIDGETS + self.AUTHENTICATION_OIDC_ADVANCED_WIDGETS:
+                widget.show()
+        else:
+            for widget in self.AUTHENTICATION_OIDC_WIDGETS + self.AUTHENTICATION_OIDC_ADVANCED_WIDGETS:
+                widget.hide()
 
         # after hiding authentication widgets dialog might shrink
         self.window.adjustSize()
@@ -285,7 +326,11 @@ class DialogServer(Dialog):
                         self.window.__dict__[widget].setValue(self.server_conf.__dict__[setting])
 
             # set the current authentication type by using capitalized first letter via .title()
-            self.window.input_combobox_authentication.setCurrentText(self.server_conf.authentication.title())
+            # special case for all-caps types like OIDC and ECP
+            auth_display = self.server_conf.authentication.title()
+            if auth_display.lower() in ('oidc', 'ecp'):
+                auth_display = auth_display.upper()
+            self.window.input_combobox_authentication.setCurrentText(auth_display)
 
             # initially hide unnecessary widgets
             self.toggle_type()
@@ -370,6 +415,13 @@ class DialogServer(Dialog):
         """
         evaluate the state of widgets to get new configuration
         """
+        # Block OK if OIDC token exchange is still in progress
+        if getattr(self, '_oidc_authenticating', False):
+            QMessageBox.information(self.window, 'Nagstamon',
+                                    'OIDC authentication is still in progress.\n'
+                                    'Please wait for "Authenticated successfully!" to appear.')
+            return
+
         # strip name to avoid whitespace
         server_name = self.window.input_lineedit_name.text().strip()
 
@@ -439,6 +491,20 @@ class DialogServer(Dialog):
             self.server_conf.name = server_name
             conf.servers[server_name] = self.server_conf
 
+            # save OIDC tokens BEFORE create_server so the new server instance can load them
+            if self.server_conf.authentication == 'oidc' and hasattr(self, '_oidc_token_result'):
+                token_result = self._oidc_token_result
+                oidc_config = getattr(self, '_oidc_config', {})
+                save_oidc_tokens(server_name, {
+                    'access_token': token_result.access_token,
+                    'refresh_token': token_result.refresh_token or '',
+                    'id_token': token_result.id_token or '',
+                    'expires_at': token_result.expires_at,
+                    'token_endpoint': oidc_config.get('token_endpoint', ''),
+                    'authorization_endpoint': oidc_config.get('authorization_endpoint', ''),
+                    'client_id': self.server_conf.oidc_client_id or 'nagstamon',
+                })
+
             # add new server instance to global servers dict
             servers[server_name] = create_server(self.server_conf)
             if self.server_conf.enabled:
@@ -490,6 +556,77 @@ class DialogServer(Dialog):
     @Slot()
     def checkmk_view_services_reset(self):
         self.window.input_lineedit_checkmk_view_services.setText('nagstamon_svc')
+
+    def on_oidc_authenticate(self):
+        """
+        Start OIDC authentication flow in system browser
+        """
+        monitor_url = self.window.input_lineedit_monitor_url.text().strip().rstrip('/')
+        if not monitor_url:
+            QMessageBox.warning(self.window, 'Nagstamon',
+                                'Please enter the Monitor URL first.')
+            return
+
+        client_id = self.window.input_lineedit_oidc_client_id.text().strip() or 'nagstamon'
+        redirect_port = self.window.input_spinbox_oidc_redirect_port.value()
+
+        self.window.button_oidc_authenticate.setEnabled(False)
+        self._oidc_status_update.emit('Discovering OIDC endpoints...')
+        self._oidc_authenticating = True
+
+        def _run():
+            try:
+                import requests
+                if conf.debug_mode:
+                    print(f'[OIDC] Dialog: Starting OIDC discovery for {monitor_url}')
+                    print(f'[OIDC] Dialog: client_id={client_id}, redirect_port={redirect_port}')
+                session = requests.Session()
+                session.verify = not self.window.input_checkbox_ignore_cert.isChecked()
+                oidc_config = discover_oidc_from_icingaweb2(monitor_url, session, timeout=15)
+
+                if conf.debug_mode:
+                    print(f'[OIDC] Dialog: Discovery OK: auth_endpoint={oidc_config["authorization_endpoint"]}')
+                    print(f'[OIDC] Dialog: Discovery OK: token_endpoint={oidc_config["token_endpoint"]}')
+                    if oidc_config.get('server_client_id'):
+                        print(f'[OIDC] Dialog: Server-side OIDC client_id={oidc_config["server_client_id"]}')
+                        print(f'[OIDC] Dialog: If you get 401s, ensure the token for client "{client_id}" '
+                              f'includes "{oidc_config["server_client_id"]}" in the aud claim')
+
+                self._oidc_status_update.emit('Waiting for browser login...')
+
+                authenticator = OIDCAuthenticator(
+                    authorization_endpoint=oidc_config['authorization_endpoint'],
+                    token_endpoint=oidc_config['token_endpoint'],
+                    client_id=client_id,
+                    redirect_port=redirect_port,
+                )
+                token_result = authenticator.authenticate(timeout=120)
+
+                # Store tokens temporarily on the dialog for ok() to pick up
+                self._oidc_token_result = token_result
+                self._oidc_config = oidc_config
+                if conf.debug_mode:
+                    import time as _time
+                    remaining = token_result.expires_at - _time.time()
+                    print(f'[OIDC] Dialog: Authentication successful! '
+                          f'expires_in={remaining:.0f}s, has_refresh={bool(token_result.refresh_token)}')
+                self._oidc_status_update.emit('Authenticated successfully!')
+            except OIDCError as e:
+                if conf.debug_mode:
+                    print(f'[OIDC] Dialog: OIDCError: {e}')
+                self._oidc_status_update.emit(f'Error: {e}')
+            except Exception as e:
+                if conf.debug_mode:
+                    import traceback
+                    print(f'[OIDC] Dialog: Unexpected error: {e}')
+                    traceback.print_exc()
+                self._oidc_status_update.emit(f'Error: {e}')
+            finally:
+                self._oidc_authenticating = False
+                self._oidc_auth_finished.emit()
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
 
     def on_delete_web_cookies(self):
         """

--- a/Nagstamon/qui/widgets/server_vbox.py
+++ b/Nagstamon/qui/widgets/server_vbox.py
@@ -14,9 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+import threading
+
 from Nagstamon.config import (conf,
                               OS,
                               OS_MACOS)
+from Nagstamon.cookies import save_oidc_tokens
 from Nagstamon.qui.constants import (HEADERS,
                                      HEADERS_KEYS_COLUMNS,
                                      HEADERS_HEADERS_COLUMNS,
@@ -34,6 +37,11 @@ from Nagstamon.qui.widgets.labels import (ClosingLabel,
                                           ServerStatusLabel)
 from Nagstamon.qui.widgets.layout import HBoxLayout
 from Nagstamon.qui.widgets.treeview import TreeView
+from Nagstamon.thirdparty.oidc_auth import (
+    discover_oidc_from_icingaweb2,
+    OIDCAuthenticator,
+    OIDCError,
+)
 
 
 class ServerVBox(QVBoxLayout):
@@ -59,6 +67,10 @@ class ServerVBox(QVBoxLayout):
 
     # open dialog - may need closing the statuswindow
     open_dialog = Signal()
+
+    # signals for thread-safe OIDC UI updates from background thread
+    _oidc_status_update = Signal(str)
+    _oidc_auth_finished = Signal()
 
     def __init__(self, server, parent=None):
         QVBoxLayout.__init__(self, parent)
@@ -114,6 +126,8 @@ class ServerVBox(QVBoxLayout):
 
         self.button_authenticate = QPushButton('Authenticate', parent=parent)
 
+        self.button_oidc_auth = QPushButton('Authenticate', parent=parent)
+
         self.button_fix_tls_error = QPushButton('Fix error', parent=parent)
 
         # avoid useless spaces in macOS when server has nothing to show
@@ -124,6 +138,7 @@ class ServerVBox(QVBoxLayout):
         self.button_hosts.setAttribute(Qt.WidgetAttribute.WA_LayoutUsesWidgetRect)
         self.button_edit.setAttribute(Qt.WidgetAttribute.WA_LayoutUsesWidgetRect)
         self.button_authenticate.setAttribute(Qt.WidgetAttribute.WA_LayoutUsesWidgetRect)
+        self.button_oidc_auth.setAttribute(Qt.WidgetAttribute.WA_LayoutUsesWidgetRect)
         self.button_fix_tls_error.setAttribute(Qt.WidgetAttribute.WA_LayoutUsesWidgetRect)
 
         self.button_monitor.clicked.connect(self.button_monitor.open_url)
@@ -142,6 +157,7 @@ class ServerVBox(QVBoxLayout):
         self.header.addWidget(self.label_stretcher)
 
         self.header.addWidget(self.label_status)
+        self.header.addWidget(self.button_oidc_auth)
         self.header.addWidget(self.button_authenticate)
         self.header.addWidget(self.button_fix_tls_error)
 
@@ -170,6 +186,10 @@ class ServerVBox(QVBoxLayout):
 
         # care about authentications
         self.button_authenticate.clicked.connect(self.authenticate_server)
+        self.button_oidc_auth.clicked.connect(self.oidc_auth_server)
+        # thread-safe OIDC UI updates
+        self._oidc_status_update.connect(self.label_status.setText)
+        self._oidc_auth_finished.connect(self._on_oidc_auth_finished)
         # somehow a long way to connect the signal with the slot but works
         self.authenticate_credentials.connect(self.parent_statuswindow.injected_dialogs.authentication.show_auth_dialog)
         self.authenticate_weblogin.connect(self.parent_statuswindow.injected_dialogs.weblogin.show_browser)
@@ -206,6 +226,7 @@ class ServerVBox(QVBoxLayout):
         show all items in server vbox
         """
         self.button_authenticate.hide()
+        self.button_oidc_auth.hide()
         self.button_edit.show()
         self.button_fix_tls_error.hide()
         self.button_history.show()
@@ -225,6 +246,7 @@ class ServerVBox(QVBoxLayout):
         show all items in server vbox except the table - not needed if empty or major connection problem
         """
         self.button_authenticate.hide()
+        self.button_oidc_auth.hide()
         self.button_edit.show()
         self.button_history.show()
         self.button_hosts.show()
@@ -243,6 +265,7 @@ class ServerVBox(QVBoxLayout):
         hide all items in server vbox
         """
         self.button_authenticate.hide()
+        self.button_oidc_auth.hide()
         self.button_edit.hide()
         self.button_fix_tls_error.hide()
         self.button_history.hide()
@@ -269,6 +292,7 @@ class ServerVBox(QVBoxLayout):
                        self.label_status,
                        self.label_stretcher,
                        self.button_authenticate,
+                       self.button_oidc_auth,
                        self.button_fix_tls_error):
             widget.hide()
             widget.deleteLater()
@@ -290,10 +314,105 @@ class ServerVBox(QVBoxLayout):
         """
         send signal to open authentication dialog with self.server.name
         """
-        if self.server.authentication != 'web':
+        if self.server.authentication == 'oidc':
+            # OIDC needs the server settings dialog (with its Authenticate button), not a password prompt
+            self.button_edit_pressed.emit(self.server.name)
+        elif self.server.authentication != 'web':
             self.authenticate_credentials.emit(self.server.name)
         else:
             self.authenticate_weblogin.emit(self.server.name)
+
+    def _iter_sibling_vboxes(self):
+        """Yield all ServerVBox siblings from the status window."""
+        for child in self.parent_statuswindow.servers_vbox.children():
+            if isinstance(child, ServerVBox):
+                yield child
+
+    def _on_oidc_auth_finished(self):
+        """Re-enable all OIDC Auth buttons after auth completes."""
+        for vbox in self._iter_sibling_vboxes():
+            if vbox.server.authentication == 'oidc':
+                vbox.button_oidc_auth.setEnabled(True)
+
+    def oidc_auth_server(self):
+        """
+        Directly trigger OIDC authentication flow from the status window
+        """
+        monitor_url = self.server.monitor_url
+        if not monitor_url:
+            return
+
+        server_name = self.server.name
+        server_conf = conf.servers.get(server_name)
+        client_id = getattr(server_conf, 'oidc_client_id', 'nagstamon') if server_conf else 'nagstamon'
+        redirect_port = getattr(server_conf, 'oidc_redirect_port', 12345) if server_conf else 12345
+
+        self.button_oidc_auth.setEnabled(False)
+        self._oidc_status_update.emit('Discovering OIDC endpoints...')
+
+        # Disable all other OIDC Auth buttons to prevent concurrent auth flows
+        # (concurrent flows would fail because the callback port is already in use)
+        for vbox in self._iter_sibling_vboxes():
+            if vbox is not self and vbox.server.authentication == 'oidc':
+                vbox.button_oidc_auth.setEnabled(False)
+
+        def _run():
+            try:
+                import requests
+                if conf.debug_mode:
+                    print(f'[OIDC] StatusWindow: Starting OIDC discovery for {monitor_url}')
+                session = requests.Session()
+                session.verify = not self.server.ignore_cert
+                oidc_config = discover_oidc_from_icingaweb2(monitor_url, session, timeout=15)
+
+                if conf.debug_mode:
+                    print(f'[OIDC] StatusWindow: Discovery OK: token_endpoint={oidc_config["token_endpoint"]}')
+
+                self._oidc_status_update.emit('Waiting for browser login...')
+
+                authenticator = OIDCAuthenticator(
+                    authorization_endpoint=oidc_config['authorization_endpoint'],
+                    token_endpoint=oidc_config['token_endpoint'],
+                    client_id=client_id,
+                    redirect_port=redirect_port,
+                )
+                token_result = authenticator.authenticate(timeout=120)
+
+                # Persist tokens so the server picks them up on next session creation
+                save_oidc_tokens(server_name, {
+                    'access_token': token_result.access_token,
+                    'refresh_token': token_result.refresh_token or '',
+                    'id_token': token_result.id_token or '',
+                    'expires_at': token_result.expires_at,
+                    'token_endpoint': oidc_config.get('token_endpoint', ''),
+                    'authorization_endpoint': oidc_config.get('authorization_endpoint', ''),
+                    'client_id': client_id,
+                })
+
+                # Reset the server's HTTP session so it reloads fresh tokens
+                self.server.reset_http()
+
+                if conf.debug_mode:
+                    import time as _time
+                    remaining = token_result.expires_at - _time.time()
+                    print(f'[OIDC] StatusWindow: Authentication successful! '
+                          f'expires_in={remaining:.0f}s, has_refresh={bool(token_result.refresh_token)}')
+                self._oidc_status_update.emit('Authenticated successfully!')
+            except OIDCError as e:
+                if conf.debug_mode:
+                    print(f'[OIDC] StatusWindow: OIDCError: {e}')
+                self._oidc_status_update.emit(f'Error: {e}')
+            except Exception as e:
+                if conf.debug_mode:
+                    import traceback
+                    print(f'[OIDC] StatusWindow: Unexpected error: {e}')
+                    traceback.print_exc()
+                self._oidc_status_update.emit(f'Error: {e}')
+            finally:
+                self._oidc_auth_finished.emit()
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
 
     @Slot()
     def update_label(self):

--- a/Nagstamon/qui/widgets/statuswindow.py
+++ b/Nagstamon/qui/widgets/statuswindow.py
@@ -597,6 +597,7 @@ class StatusWindow(QWidget):
                     not conf.servers[server.name].use_autologin and \
                     conf.servers[server.name].password == '' and \
                     not conf.servers[server.name].authentication == 'kerberos' and \
+                    not conf.servers[server.name].authentication == 'oidc' and \
                     not conf.servers[server.name].authentication == 'web':
                 self.authenticate.emit(server.name)
 
@@ -784,6 +785,12 @@ class StatusWindow(QWidget):
                         vbox.button_authenticate.show()
                     else:
                         vbox.button_authenticate.hide()
+
+                    # always show OIDC Auth button for OIDC servers
+                    if vbox.server.authentication == 'oidc':
+                        vbox.button_oidc_auth.show()
+                    else:
+                        vbox.button_oidc_auth.hide()
 
                     # depending on TLS error show fix-TLS-button
                     if vbox.server.tls_error:

--- a/Nagstamon/resources/qui/settings_server.ui
+++ b/Nagstamon/resources/qui/settings_server.ui
@@ -307,6 +307,40 @@
       <item row="36" column="2" colspan="3">
        <widget class="QLineEdit" name="input_lineedit_idp_ecp_endpoint"/>
       </item>
+      <item row="38" column="1">
+       <widget class="QLabel" name="label_oidc_client_id">
+        <property name="text">
+         <string>OIDC Client ID:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="38" column="2" colspan="3">
+       <widget class="QLineEdit" name="input_lineedit_oidc_client_id">
+        <property name="text">
+         <string>nagstamon</string>
+        </property>
+       </widget>
+      </item>
+      <item row="39" column="1">
+       <widget class="QLabel" name="label_oidc_redirect_port">
+        <property name="text">
+         <string>OIDC Redirect Port:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="39" column="2">
+       <widget class="QSpinBox" name="input_spinbox_oidc_redirect_port">
+        <property name="minimum">
+         <number>1024</number>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+        <property name="value">
+         <number>12345</number>
+        </property>
+       </widget>
+      </item>
       <item row="5" column="4">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
@@ -801,6 +835,20 @@
      </property>
     </widget>
    </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_oidc_status">
+     <property name="text">
+      <string>Not authenticated</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QPushButton" name="button_oidc_authenticate">
+     <property name="text">
+      <string>Authenticate...</string>
+     </property>
+    </widget>
+   </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_username">
      <property name="sizePolicy">
@@ -874,6 +922,8 @@
   <tabstop>input_lineedit_checkmk_view_services</tabstop>
   <tabstop>button_checkmk_view_services_reset</tabstop>
   <tabstop>input_lineedit_idp_ecp_endpoint</tabstop>
+  <tabstop>input_lineedit_oidc_client_id</tabstop>
+  <tabstop>input_spinbox_oidc_redirect_port</tabstop>
   <tabstop>input_lineedit_disabled_backends</tabstop>
  </tabstops>
  <resources/>

--- a/Nagstamon/servers/Generic.py
+++ b/Nagstamon/servers/Generic.py
@@ -33,7 +33,10 @@ from bs4 import BeautifulSoup
 import requests
 
 from Nagstamon.cookies import (cookie_data_to_jar,
-                               load_cookies)
+                               load_cookies,
+                               load_oidc_tokens,
+                               save_oidc_tokens)
+from Nagstamon.thirdparty.oidc_auth import OIDCBearerAuth, OIDC_USER_AGENT
 
 # check ECP authentication support availability
 try:
@@ -322,8 +325,17 @@ class GenericServer:
                 self.session = None
                 return False
             elif self.session is None:
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(), debug=f'init_http: session is None, calling create_session() (auth={self.authentication})')
                 self.session = self.create_session()
+                if conf.debug_mode:
+                    auth_type = type(self.session.auth).__name__ if self.session and self.session.auth else 'None'
+                    self.debug(server=self.get_name(), debug=f'init_http: session created, auth handler={auth_type}')
                 return True
+            else:
+                if conf.debug_mode:
+                    auth_type = type(self.session.auth).__name__ if self.session.auth else 'None'
+                    self.debug(server=self.get_name(), debug=f'init_http: session already exists, auth handler={auth_type}')
         elif not self.session:
             self.session = self.create_session()
             return True
@@ -352,6 +364,40 @@ class GenericServer:
             session.auth = HTTPSKerberos()
         elif self.authentication == 'bearer':
             session.auth = BearerAuth(self.password)
+        elif self.authentication == 'oidc':
+            session.headers['User-Agent'] = OIDC_USER_AGENT
+            if hasattr(self, '_oidc_bearer_auth') and self._oidc_bearer_auth is not None:
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(), debug='[OIDC] Reusing existing OIDCBearerAuth for session')
+                session.auth = self._oidc_bearer_auth
+            else:
+                # Try to load persisted tokens
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(), debug='[OIDC] Loading persisted tokens...')
+                token_data = load_oidc_tokens(self.name)
+                if token_data and token_data.get('access_token'):
+                    if conf.debug_mode:
+                        import time as _time
+                        remaining = token_data.get('expires_at', 0) - _time.time()
+                        self.debug(server=self.get_name(),
+                                   debug=f'[OIDC] Loaded tokens: has_refresh={bool(token_data.get("refresh_token"))}, '
+                                         f'expires_in={remaining:.0f}s, '
+                                         f'token_endpoint={token_data.get("token_endpoint", "?")}')
+                    def _on_token_refreshed(new_data):
+                        save_oidc_tokens(self.name, new_data)
+                    self._oidc_bearer_auth = OIDCBearerAuth(
+                        access_token=token_data['access_token'],
+                        refresh_token=token_data.get('refresh_token', ''),
+                        token_endpoint=token_data.get('token_endpoint', ''),
+                        client_id=token_data.get('client_id', getattr(self, 'oidc_client_id', 'nagstamon')),
+                        expires_at=token_data.get('expires_at', 0),
+                        on_token_refreshed=_on_token_refreshed,
+                    )
+                    session.auth = self._oidc_bearer_auth
+                else:
+                    if conf.debug_mode:
+                        self.debug(server=self.get_name(), debug='[OIDC] No persisted tokens found, session will have no auth')
+                    session.auth = None
         elif self.authentication == 'web':
             session.auth = None
             cookies = load_cookies()
@@ -985,6 +1031,12 @@ class GenericServer:
                'bad session id' in self.status_description.lower() or \
                'login failed' in self.status_description.lower() or \
                self.status_code in self.STATUS_CODES_NO_AUTH:
+                # OIDC can't re-authenticate automatically, tell user to re-auth in settings
+                if self.authentication == 'oidc':
+                    self.isChecking = False
+                    return Result(result='ERROR',
+                                  error='OIDC authentication failed, click the Authenticate button to re-authenticate',
+                                  status_code=self.status_code)
                 if conf.servers[self.name].enabled is True:
                     # needed to get valid credentials
                     self.refresh_authentication = True
@@ -1584,6 +1636,18 @@ class GenericServer:
                 else:
                     self.tls_error = False
                 return Result(result=result, error=error, status_code=-1)
+
+            # Log details for 401 responses to diagnose auth failures
+            if conf.debug_mode and response.status_code == 401:
+                www_auth = response.headers.get('WWW-Authenticate', '(none)')
+                req_auth = response.request.headers.get('Authorization', '(none)')[:80]
+                req_ua = response.request.headers.get('User-Agent', '(none)')
+                req_xoauth = response.request.headers.get('X-OAuth2', '(none)')
+                self.debug(server=self.get_name(),
+                           debug=f'fetch_url 401: WWW-Authenticate={www_auth}, '
+                                 f'req Authorization={req_auth}, '
+                                 f'req User-Agent={req_ua}, '
+                                 f'req X-OAuth2={req_xoauth}')
 
             # store encoding in case it is not the server side encoding
             if self.encoding != response.encoding:

--- a/Nagstamon/servers/IcingaDBWeb.py
+++ b/Nagstamon/servers/IcingaDBWeb.py
@@ -120,6 +120,16 @@ class IcingaDBWebServer(GenericServer):
         if self.session and not 'Referer' in self.session.headers:
             self.session.headers['Referer'] = self.monitor_cgi_url
 
+        # OIDC authentication uses Bearer token - skip form-based login
+        if self.authentication == 'oidc':
+            if conf.debug_mode:
+                self.debug(server=self.get_name(), debug='[OIDC] Skipping form-based login (Bearer token auth), setting timezone cookie')
+            if self.session:
+                # Add icingaweb2-tzo cookie to ensure Icinga to correctly handle provide date time string
+                utc_offset = int(get_localzone().utcoffset(datetime.datetime.now()).total_seconds())
+                self.session.cookies.update(cookiejar_from_dict({'icingaweb2-tzo': f'{utc_offset}-0'}))
+            return
+
         # normally cookie auth will be used
         if not self.no_cookie_auth:
             if 'cookies' not in dir(self.session) or len(self.session.cookies) == 0:
@@ -192,10 +202,20 @@ class IcingaDBWebServer(GenericServer):
             for status_type in 'hard', 'soft':
                 # first attempt
                 result = self.fetch_url(self.cgiurl_hosts[status_type], giveback='raw')
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(),
+                              debug=f'hosts {status_type} response: status={result.status_code}, '
+                                    f'error="{result.error}", '
+                                    f'body_start={repr(result.result[:300]) if result.result else "(empty)"}')
                 # authentication errors get a status code 200 too back because its
                 # HTML works fine :-(
                 if result.status_code < 400 and\
                    result.result.startswith('<'):
+                    # OIDC can't re-authenticate automatically — tell user to re-auth in settings
+                    if self.authentication == 'oidc':
+                        return Result(result=result.result,
+                                      error='OIDC token missing or expired \u2014 click the Authenticate button to re-authenticate',
+                                      status_code=result.status_code)
                     # in case of auth error reset HTTP session and try again
                     self.reset_http()
                     result = self.fetch_url(self.cgiurl_hosts[status_type], giveback='raw')
@@ -235,6 +255,9 @@ class IcingaDBWebServer(GenericServer):
                     #     self.cgiurl_monitoring_health = None
 
                 hosts = json.loads(jsonraw)
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(),
+                              debug=f'hosts {status_type} parsed: {len(hosts)} host(s), type={type(hosts).__name__}')
 
                 for host in hosts:
                     # make dict of tuples for better reading
@@ -318,6 +341,11 @@ class IcingaDBWebServer(GenericServer):
         try:
             for status_type in 'hard', 'soft':
                 result = self.fetch_url(self.cgiurl_services[status_type], giveback='raw')
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(),
+                              debug=f'services {status_type} response: status={result.status_code}, '
+                                    f'error="{result.error}", '
+                                    f'body_start={repr(result.result[:300]) if result.result else "(empty)"}')
                 # purify JSON result of unnecessary control sequence \n
                 jsonraw, error, status_code = copy.deepcopy(result.result.replace('\n', '')),\
                                               copy.deepcopy(result.error),\
@@ -332,6 +360,9 @@ class IcingaDBWebServer(GenericServer):
                 self.check_for_error(jsonraw, error, status_code)
 
                 services = copy.deepcopy(json.loads(jsonraw))
+                if conf.debug_mode:
+                    self.debug(server=self.get_name(),
+                              debug=f'services {status_type} parsed: {len(services)} service(s), type={type(services).__name__}')
 
                 for service in services:
                     # make dict of tuples for better reading
@@ -429,6 +460,12 @@ class IcingaDBWebServer(GenericServer):
 
         # some cleanup
         del jsonraw, error, hosts, services
+
+        if conf.debug_mode:
+            total_hosts = len(self.new_hosts)
+            total_services = sum(len(h.services) for h in self.new_hosts.values())
+            self.debug(server=self.get_name(),
+                       debug=f'_get_status complete: {total_hosts} host(s), {total_services} service(s) in new_hosts')
 
         # dummy return in case all is OK
         return Result()

--- a/Nagstamon/servers/__init__.py
+++ b/Nagstamon/servers/__init__.py
@@ -173,8 +173,9 @@ def create_server(server=None):
     new_server.idp_ecp_endpoint = server.idp_ecp_endpoint
 
     # if password is not to be saved ask for it at startup
+    # OIDC uses persisted tokens, not passwords, don't trigger refresh_authentication
     if (server.enabled is True and server.save_password is False and
-            server.use_autologin is False):
+            server.use_autologin is False and server.authentication != 'oidc'):
         new_server.refresh_authentication = True
 
     # Special FX

--- a/Nagstamon/thirdparty/oidc_auth.py
+++ b/Nagstamon/thirdparty/oidc_auth.py
@@ -1,0 +1,560 @@
+# Nagstamon - Nagios status monitor for your desktop
+# Copyright (C) 2008-2026 Henri Wahl <henri@nagstamon.de> et al.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+"""
+OIDC authentication helper for Nagstamon.
+
+Implements Authorization Code flow with PKCE via the system browser.
+Auto-discovers the OIDC issuer from the server's login redirect.
+Uses only stdlib + requests (no additional dependencies).
+"""
+
+import base64
+import hashlib
+import html
+import json as _json
+import secrets
+import socket
+import threading
+import time
+import webbrowser
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlencode, urlparse, parse_qs
+
+import requests
+
+from Nagstamon.config import AppInfo, conf, debug_queue
+import datetime
+
+# User-Agent sent during OIDC discovery and token requests, identifying Nagstamon as an OIDC client
+OIDC_USER_AGENT = f'NagstamonOIDC/{AppInfo.VERSION}'
+
+
+def _debug(msg):
+    """Log an OIDC debug message if debug_mode is enabled."""
+    if conf.debug_mode:
+        debug_queue.append(f'DEBUG: {datetime.datetime.now()} [OIDC] {msg}')
+
+
+class OIDCError(Exception):
+    """Base exception for OIDC authentication errors."""
+    pass
+
+
+class OIDCTimeoutError(OIDCError):
+    """Raised when the browser authentication times out."""
+    pass
+
+
+class OIDCDiscoveryError(OIDCError):
+    """Raised when OIDC provider discovery fails."""
+    pass
+
+
+class OIDCTokenError(OIDCError):
+    """Raised when token exchange or refresh fails."""
+    pass
+
+
+class TokenResult:
+    """Holds the result of an OIDC token exchange or refresh."""
+
+    def __init__(self, access_token, refresh_token=None, id_token=None, expires_at=None):
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.id_token = id_token
+        self.expires_at = expires_at
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """HTTP request handler that captures the OIDC authorization code callback."""
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+        _debug(f'CallbackHandler: received {self.command} {parsed.path} (params: {list(params.keys())})')
+
+        if parsed.path == '/callback':
+            if 'error' in params:
+                error = html.escape(params['error'][0])
+                desc = html.escape(params.get('error_description', [''])[0])
+                self.server.oidc_error = f'{error}: {desc}'
+                self.server.oidc_code = None
+                self._send_response('Authentication failed. You can close this tab.')
+            elif 'code' in params:
+                self.server.oidc_code = params['code'][0]
+                self.server.oidc_state = params.get('state', [None])[0]
+                self.server.oidc_error = None
+                _debug(f'CallbackHandler: got code=<redacted>, state=<redacted>')
+                self._send_response('Authentication successful! You can close this tab.')
+            else:
+                self.server.oidc_error = 'No authorization code received'
+                self.server.oidc_code = None
+                self._send_response('Authentication failed. You can close this tab.')
+        else:
+            self.send_error(404)
+            return
+
+        # signal the waiting thread that we received a response
+        _debug(f'CallbackHandler: setting event (code={bool(self.server.oidc_code)}, error={self.server.oidc_error})')
+        self.server.oidc_event.set()
+
+    def _send_response(self, message):
+        is_success = 'successful' in message.lower()
+        icon = '&#10004;' if is_success else '&#10008;'
+        color = '#2e7d32' if is_success else '#c62828'
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.end_headers()
+        body = (
+            '<!DOCTYPE html><html><head>'
+            '<title>Nagstamon OIDC</title>'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">'
+            '<style>'
+            'body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;'
+            '  display: flex; justify-content: center; align-items: center; min-height: 100vh;'
+            '  margin: 0; background: #f5f5f5; color: #333; }'
+            '.card { background: #fff; border-radius: 12px; padding: 48px; text-align: center;'
+            '  box-shadow: 0 2px 12px rgba(0,0,0,0.1); max-width: 420px; }'
+            f'.icon {{ font-size: 64px; color: {color}; margin-bottom: 16px; }}'
+            f'h2 {{ color: {color}; margin: 0 0 12px; font-size: 22px; }}'
+            'p { color: #666; margin: 0; font-size: 14px; }'
+            '</style></head><body>'
+            f'<div class="card"><div class="icon">{icon}</div>'
+            f'<h2>{html.escape(message)}</h2>'
+            '<p>This tab will close automatically...</p>'
+            '</div>'
+            '<script>setTimeout(function(){window.close();},3000);</script>'
+            '</body></html>'
+        )
+        self.wfile.write(body.encode('utf-8'))
+
+    def log_message(self, format, *args):
+        # suppress default stderr logging
+        pass
+
+
+def _generate_pkce():
+    """Generate PKCE code_verifier and code_challenge (S256) per RFC 7636."""
+    # 64 bytes -> 86 chars base64url (well within the 43-128 range required by spec)
+    code_verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(code_verifier.encode('ascii')).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b'=').decode('ascii')
+    return code_verifier, code_challenge
+
+
+class _ReusableHTTPServer(HTTPServer):
+    """HTTPServer with SO_REUSEADDR so the port is freed immediately after close."""
+    allow_reuse_address = True
+    allow_reuse_port = True
+
+
+def discover_oidc_from_icingaweb2(monitor_url, session=None, timeout=15):
+    """
+    Auto-discover the OIDC issuer and endpoints from IcingaWeb2's login redirect.
+
+    IcingaWeb2 configured with OIDC (e.g., mod_auth_openidc or its own OIDC module)
+    will redirect the login page to Keycloak. We follow that redirect to extract
+    the issuer URL, then fetch the .well-known/openid-configuration.
+
+    Args:
+        monitor_url: The IcingaWeb2 base URL (e.g., https://icinga.example.com/icingaweb2)
+        session: Optional requests.Session for proxy/TLS settings
+        timeout: Request timeout in seconds
+
+    Returns:
+        dict with keys: issuer, authorization_endpoint, token_endpoint, end_session_endpoint
+
+    Raises:
+        OIDCDiscoveryError if discovery fails
+    """
+    if session is None:
+        session = requests.Session()
+
+    session.headers['User-Agent'] = OIDC_USER_AGENT
+
+    login_url = f'{monitor_url.rstrip("/")}/authentication/login'
+    _debug(f'Discovery: fetching login page {login_url}')
+
+    try:
+        # Don't follow redirects, we need to capture the Location header
+        response = session.get(login_url, allow_redirects=False, timeout=timeout)
+        _debug(f'Discovery: login page returned status {response.status_code}')
+    except requests.RequestException as e:
+        raise OIDCDiscoveryError(f'Failed to connect to {login_url}: {e}')
+
+    # Follow redirects manually to find the OIDC authorization endpoint
+    redirect_url = None
+    server_client_id = None
+    max_redirects = 10
+    current_response = response
+    current_url = login_url
+    for i in range(max_redirects):
+        if current_response.status_code in (301, 302, 303, 307, 308):
+            location = current_response.headers.get('Location', '')
+            if not location:
+                break
+            # Resolve relative redirects against current URL
+            if not location.startswith(('http://', 'https://')):
+                from urllib.parse import urljoin
+                location = urljoin(current_url, location)
+            redirect_url = location
+            _debug(f'Discovery: redirect #{i+1} -> {redirect_url}')
+
+            # Stop at the first redirect that looks like an OIDC authorization endpoint
+            # (detected by the presence of client_id in the query params, which is required by RFC 6749)
+            redirect_parsed_check = urlparse(redirect_url)
+            redirect_params_check = parse_qs(redirect_parsed_check.query)
+            if 'client_id' in redirect_params_check:
+                _debug(f'Discovery: found OIDC endpoint in redirect #{i+1}, stopping redirect chase')
+                # Extract the server-side client_id from the redirect query params
+                if 'client_id' in redirect_params_check:
+                    server_client_id = redirect_params_check['client_id'][0]
+                    _debug(f'Discovery: server-side client_id={server_client_id}')
+                break
+
+            try:
+                current_url = redirect_url
+                current_response = session.get(redirect_url, allow_redirects=False, timeout=timeout)
+            except requests.RequestException:
+                break
+        else:
+            break
+
+    if not redirect_url:
+        raise OIDCDiscoveryError(
+            f'No OIDC redirect found at {login_url}. '
+            'Make sure IcingaWeb2 is configured to redirect to your OIDC provider.'
+        )
+
+    # Extract the issuer URL from the redirect URL by stripping well-known OIDC path segments.
+    # e.g. https://idp.example.com/realms/myrealm/protocol/openid-connect/auth -> https://idp.example.com/realms/myrealm
+    #      https://idp.example.com/oauth2/v1/authorize                         -> https://idp.example.com/oauth2
+    parsed = urlparse(redirect_url)
+    path = parsed.path
+
+    # Find the issuer base path, look for /protocol/openid-connect or /auth in the path
+    issuer_path = path
+    for marker in ('/protocol/openid-connect', '/.well-known'):
+        idx = path.find(marker)
+        if idx != -1:
+            issuer_path = path[:idx]
+            break
+
+    issuer_url = f'{parsed.scheme}://{parsed.netloc}{issuer_path}'
+    _debug(f'Discovery: extracted issuer URL: {issuer_url}')
+
+    # Fetch the OIDC well-known configuration
+    well_known_url = f'{issuer_url}/.well-known/openid-configuration'
+    _debug(f'Discovery: fetching well-known config from {well_known_url}')
+    try:
+        wk_response = session.get(well_known_url, timeout=timeout)
+        wk_response.raise_for_status()
+        oidc_config = wk_response.json()
+        _debug(f'Discovery: got OIDC config with endpoints: auth={oidc_config.get("authorization_endpoint")}, token={oidc_config.get("token_endpoint")}')
+    except (requests.RequestException, ValueError) as e:
+        raise OIDCDiscoveryError(f'Failed to fetch OIDC configuration from {well_known_url}: {e}')
+
+    required_keys = ['authorization_endpoint', 'token_endpoint']
+    for key in required_keys:
+        if key not in oidc_config:
+            raise OIDCDiscoveryError(f'OIDC configuration missing required key: {key}')
+
+    return {
+        'issuer': oidc_config.get('issuer', issuer_url),
+        'authorization_endpoint': oidc_config['authorization_endpoint'],
+        'token_endpoint': oidc_config['token_endpoint'],
+        'end_session_endpoint': oidc_config.get('end_session_endpoint', ''),
+        'server_client_id': server_client_id,
+    }
+
+
+class OIDCAuthenticator:
+    """
+    Handles OIDC Authorization Code flow with PKCE via the system browser.
+
+    Usage:
+        authenticator = OIDCAuthenticator(
+            authorization_endpoint='https://idp.example.com/oauth2/authorize',
+            token_endpoint='https://idp.example.com/oauth2/token',
+            client_id='nagstamon',
+            redirect_port=12345,
+        )
+        result = authenticator.authenticate()
+        # result.access_token, result.refresh_token, result.expires_at
+    """
+
+    def __init__(self, authorization_endpoint, token_endpoint, client_id='nagstamon',
+                 redirect_port=12345, scope='openid', session=None):
+        self.authorization_endpoint = authorization_endpoint
+        self.token_endpoint = token_endpoint
+        self.client_id = client_id
+        self.redirect_port = redirect_port
+        self.scope = scope
+        self.session = session or requests.Session()
+        self.session.headers['User-Agent'] = OIDC_USER_AGENT
+
+    def authenticate(self, timeout=120):
+        """
+        Run the full OIDC Authorization Code + PKCE flow.
+
+        1. Start a local HTTP server for the callback
+        2. Open the system browser to the authorization URL
+        3. Wait for the callback with the authorization code
+        4. Exchange the code for tokens
+
+        Args:
+            timeout: Seconds to wait for the user to complete authentication
+
+        Returns:
+            TokenResult with access_token, refresh_token, id_token, expires_at
+
+        Raises:
+            OIDCTimeoutError if the user doesn't complete auth within timeout
+            OIDCTokenError if token exchange fails
+        """
+        code_verifier, code_challenge = _generate_pkce()
+        state = secrets.token_urlsafe(32)
+
+        port = self.redirect_port
+        redirect_uri = f'http://localhost:{port}/callback'
+
+        # Build authorization URL
+        auth_params = {
+            'client_id': self.client_id,
+            'response_type': 'code',
+            'redirect_uri': redirect_uri,
+            'scope': self.scope,
+            'state': state,
+            'code_challenge': code_challenge,
+            'code_challenge_method': 'S256',
+        }
+        auth_url = f'{self.authorization_endpoint}?{urlencode(auth_params)}'
+        _debug(f'Authenticate: starting callback server on port {port}')
+        _debug(f'Authenticate: authorization URL: {self.authorization_endpoint} (client_id={self.client_id})')
+
+        # Start local callback server (SO_REUSEADDR ensures port is freed immediately)
+        try:
+            server = _ReusableHTTPServer(('127.0.0.1', port), _CallbackHandler)
+        except OSError as e:
+            raise OIDCError(
+                f'Port {port} is already in use — another OIDC login may be in progress. '
+                f'Please wait for it to finish or close the previous browser tab.'
+            ) from e
+        server.oidc_code = None
+        server.oidc_state = None
+        server.oidc_error = None
+        server.oidc_event = threading.Event()
+        server.timeout = 1  # handle_request timeout for clean shutdown
+
+        # Run server in a background thread
+        server_thread = threading.Thread(target=self._run_server, args=(server, timeout), daemon=True)
+        server_thread.start()
+
+        # Open the system browser
+        _debug('Authenticate: opening system browser for login')
+        webbrowser.open(auth_url)
+
+        # Wait for the callback
+        _debug(f'Authenticate: waiting up to {timeout}s for callback...')
+        if not server.oidc_event.wait(timeout=timeout):
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=5)
+            raise OIDCTimeoutError(f'Authentication timed out after {timeout} seconds')
+
+        _debug(f'Authenticate: event fired, code={bool(server.oidc_code)}, error={server.oidc_error}')
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+        _debug('Authenticate: server thread joined')
+
+        if server.oidc_error:
+            _debug(f'Authenticate: error from callback: {server.oidc_error}')
+            raise OIDCError(f'Authentication error: {server.oidc_error}')
+
+        if not server.oidc_code:
+            raise OIDCError('No authorization code received')
+
+        # Validate state
+        if server.oidc_state != state:
+            _debug('Authenticate: state mismatch!')
+            raise OIDCError('State mismatch — possible CSRF attack')
+
+        _debug('Authenticate: received authorization code, exchanging for tokens...')
+        # Exchange authorization code for tokens
+        return self._exchange_code(server.oidc_code, redirect_uri, code_verifier)
+
+    def _run_server(self, server, timeout):
+        """Run the HTTP server until shutdown() is called."""
+        server.serve_forever(poll_interval=0.5)
+
+    def _exchange_code(self, code, redirect_uri, code_verifier):
+        """Exchange authorization code for tokens at the token endpoint."""
+        _debug(f'TokenExchange: posting to {self.token_endpoint}')
+        token_data = {
+            'grant_type': 'authorization_code',
+            'client_id': self.client_id,
+            'code': code,
+            'redirect_uri': redirect_uri,
+            'code_verifier': code_verifier,
+        }
+        try:
+            response = self.session.post(self.token_endpoint, data=token_data, timeout=15)
+            _debug(f'TokenExchange: response status {response.status_code}')
+            response.raise_for_status()
+            token_json = response.json()
+        except (requests.RequestException, ValueError) as e:
+            _debug(f'TokenExchange: failed: {e}')
+            raise OIDCTokenError(f'Token exchange failed: {e}')
+
+        access_token = token_json.get('access_token')
+        if not access_token:
+            _debug(f'TokenExchange: no access_token in response keys: {list(token_json.keys())}')
+            raise OIDCTokenError('No access_token in token response')
+
+        expires_in = token_json.get('expires_in', 300)
+        expires_at = time.time() + int(expires_in)
+        _debug(f'TokenExchange: success, expires_in={expires_in}s, has_refresh={bool(token_json.get("refresh_token"))}')
+
+        return TokenResult(
+            access_token=access_token,
+            refresh_token=token_json.get('refresh_token'),
+            id_token=token_json.get('id_token'),
+            expires_at=expires_at,
+        )
+
+    def refresh(self, refresh_token):
+        """
+        Use a refresh_token to obtain a new access_token.
+
+        Args:
+            refresh_token: The refresh token from a previous authentication
+
+        Returns:
+            TokenResult with new access_token, refresh_token, expires_at
+
+        Raises:
+            OIDCTokenError if refresh fails
+        """
+        _debug(f'TokenRefresh: refreshing token at {self.token_endpoint}')
+        token_data = {
+            'grant_type': 'refresh_token',
+            'client_id': self.client_id,
+            'refresh_token': refresh_token,
+        }
+        try:
+            response = self.session.post(self.token_endpoint, data=token_data, timeout=15)
+            _debug(f'TokenRefresh: response status {response.status_code}')
+            response.raise_for_status()
+            token_json = response.json()
+        except (requests.RequestException, ValueError) as e:
+            _debug(f'TokenRefresh: failed: {e}')
+            raise OIDCTokenError(f'Token refresh failed: {e}')
+
+        access_token = token_json.get('access_token')
+        if not access_token:
+            raise OIDCTokenError('No access_token in refresh response')
+
+        expires_in = token_json.get('expires_in', 300)
+        expires_at = time.time() + int(expires_in)
+        _debug(f'TokenRefresh: success, expires_in={expires_in}s')
+
+        return TokenResult(
+            access_token=access_token,
+            refresh_token=token_json.get('refresh_token', refresh_token),
+            id_token=token_json.get('id_token'),
+            expires_at=expires_at,
+        )
+
+
+class OIDCBearerAuth(requests.auth.AuthBase):
+    """
+    requests-compatible auth handler that uses OIDC Bearer tokens
+    with automatic refresh before expiry.
+
+    Can be constructed either with an OIDCAuthenticator instance or with
+    explicit token_endpoint/client_id for restoring from persisted tokens.
+    """
+
+    def __init__(self, access_token, refresh_token, expires_at,
+                 authenticator=None, token_endpoint=None, client_id=None,
+                 on_token_refreshed=None):
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.expires_at = expires_at
+        self.on_token_refreshed = on_token_refreshed
+        self._lock = threading.Lock()
+
+        if authenticator is not None:
+            self.authenticator = authenticator
+        elif token_endpoint:
+            # Create a minimal authenticator from persisted data
+            self.authenticator = OIDCAuthenticator(
+                authorization_endpoint='',
+                token_endpoint=token_endpoint,
+                client_id=client_id or 'nagstamon',
+            )
+        else:
+            self.authenticator = None
+
+    def __call__(self, r):
+        with self._lock:
+            # Auto-refresh if token expires within 60 seconds
+            if (self.refresh_token and self.authenticator and
+                    self.expires_at and (time.time() > self.expires_at - 60)):
+                remaining = self.expires_at - time.time()
+                _debug(f'BearerAuth: token expires in {remaining:.0f}s, refreshing...')
+                try:
+                    result = self.authenticator.refresh(self.refresh_token)
+                    self.access_token = result.access_token
+                    self.refresh_token = result.refresh_token or self.refresh_token
+                    self.expires_at = result.expires_at
+                    _debug(f'BearerAuth: token refreshed, new expiry in {result.expires_at - time.time():.0f}s')
+                    # Notify persistence layer about refreshed tokens
+                    if self.on_token_refreshed:
+                        self.on_token_refreshed({
+                            'access_token': self.access_token,
+                            'refresh_token': self.refresh_token,
+                            'id_token': '',
+                            'expires_at': self.expires_at,
+                            'token_endpoint': self.authenticator.token_endpoint,
+                            'authorization_endpoint': self.authenticator.authorization_endpoint,
+                            'client_id': self.authenticator.client_id,
+                        })
+                except OIDCTokenError as e:
+                    _debug(f'BearerAuth: refresh failed: {e}')
+                    # refresh failed, continue with current token, server will get 401
+                    pass
+
+        # Debug: decode JWT payload to show claims (no crypto verification)
+        if conf.debug_mode:
+            try:
+                parts = self.access_token.split('.')
+                if len(parts) >= 2:
+                    # Fix base64 padding
+                    payload_b64 = parts[1] + '=' * (4 - len(parts[1]) % 4)
+                    payload = _json.loads(base64.urlsafe_b64decode(payload_b64))
+                    _debug(f'BearerAuth: JWT claims: iss={payload.get("iss")}, '
+                           f'aud={payload.get("aud")}, azp={payload.get("azp")}, '
+                           f'exp={payload.get("exp")}')
+            except Exception as e:
+                _debug(f'BearerAuth: could not decode JWT: {e}')
+
+        r.headers['Authorization'] = f'Bearer {self.access_token}'
+        r.headers['X-OAuth2'] = '1'
+        return r


### PR DESCRIPTION
Adds support for OIDC (OpenID Connect) Authorization Code + PKCE authentication, enabling Nagstamon to connect to IcingaDB Web instances protected by an OIDC provider (tested with IcingaWeb2 v2.15.2 and Keycloak 26.0.5).