### PR TITLE
Hosts with UNKNOWN status are not shown in the interface

### DIFF
--- a/Nagstamon/config.py
+++ b/Nagstamon/config.py
@@ -171,6 +171,7 @@ class Config:
         self.filter_all_down_hosts = False
         self.filter_all_unreachable_hosts = False
         self.filter_all_unreachable_services = False
+        self.filter_all_unknown_hosts = False
         self.filter_all_flapping_hosts = False
         self.filter_all_unknown_services = False
         self.filter_all_information_services = False

--- a/Nagstamon/resources/qui/settings_main.ui
+++ b/Nagstamon/resources/qui/settings_main.ui
@@ -1059,27 +1059,34 @@
            </widget>
           </item>
           <item row="1" column="0">
+           <widget class="QCheckBox" name="input_checkbox_filter_all_unknown_hosts">
+            <property name="text">
+             <string>All unknown hosts</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_unreachable_hosts">
             <property name="text">
              <string>All unreachable hosts</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_unreachable_services">
             <property name="text">
              <string>All unreachable services</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_flapping_hosts">
             <property name="text">
              <string>All flapping hosts</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_critical_services">
             <property name="text">
              <string>All critical services</string>
@@ -1142,21 +1149,21 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_flapping_services">
             <property name="text">
              <string>All flapping services</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_unknown_services">
             <property name="text">
              <string>All unknown services</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="8" column="0">
            <widget class="QCheckBox" name="input_checkbox_filter_all_warning_services">
             <property name="text">
              <string>All warning services</string>
@@ -1191,14 +1198,14 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="1">
+          <item row="8" column="1">
            <widget class="QCheckBox" name="input_checkbox_filter_hosts_in_soft_state">
             <property name="text">
              <string>Hosts in soft state</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
+          <item row="9" column="1">
            <widget class="QCheckBox" name="input_checkbox_filter_services_in_soft_state">
             <property name="text">
              <string>Services in soft state</string>
@@ -3209,6 +3216,7 @@
   <tabstop>input_combobox_default_sort_field</tabstop>
   <tabstop>input_combobox_default_sort_order</tabstop>
   <tabstop>input_checkbox_filter_all_down_hosts</tabstop>
+  <tabstop>input_checkbox_filter_all_unknown_hosts</tabstop>
   <tabstop>input_checkbox_filter_all_unreachable_hosts</tabstop>
   <tabstop>input_checkbox_filter_all_flapping_hosts</tabstop>
   <tabstop>input_checkbox_filter_all_critical_services</tabstop>

--- a/Nagstamon/servers/Generic.py
+++ b/Nagstamon/servers/Generic.py
@@ -182,7 +182,7 @@ class GenericServer:
         self.nagitems_filtered_list = list()
         self.nagitems_filtered = {'services': {'DISASTER': [], 'CRITICAL': [], 'HIGH': [],
             'AVERAGE': [], 'WARNING': [], 'INFORMATION': [], 'UNKNOWN': []},
-            'hosts': {'DOWN': [], 'UNREACHABLE': []}}
+            'hosts': {'DOWN': [], 'UNREACHABLE': [], 'UNKNOWN': []}}
         # number of filtered items
         self.nagitems_filtered_count = 0
         self.down = 0
@@ -1011,7 +1011,7 @@ class GenericServer:
         # this part has been before in GUI.RefreshDisplay() - wrong place, here it needs to be reset
         self.nagitems_filtered = {'services': {'DISASTER': [], 'CRITICAL': [], 'HIGH': [],
             'AVERAGE': [], 'WARNING': [], 'INFORMATION': [], 'UNKNOWN': []},
-            'hosts': {'DOWN': [], 'UNREACHABLE': []}}
+            'hosts': {'DOWN': [], 'UNREACHABLE': [], 'UNKNOWN': []}}
 
         # initialize counts for various service/hosts states
         # count them with every miserable host/service respective to their meaning
@@ -1102,6 +1102,16 @@ class GenericServer:
                     if host.visible:
                         self.nagitems_filtered['hosts']['UNREACHABLE'].append(host)
                         self.unreachable += 1
+
+                if host.status == 'UNKNOWN':
+                    if conf.filter_all_unknown_hosts is True:
+                        if conf.debug_mode:
+                            self.debug(server=self.get_name(), debug='Filter: UNKNOWN ' + str(host.name))
+                        host.visible = False
+    
+                    if host.visible:
+                        self.nagitems_filtered['hosts']['UNKNOWN'].append(host)
+                        self.unknown += 1
 
                 # Add host flags for status icons in treeview
                 if host.acknowledged:


### PR DESCRIPTION
Hello,
 
Here is the pull request mentioned in the #1197
We noticed that Livestatus creates hosts with the UNKNOWN state and these hosts weren't displayed in the interface, because the variable self.nagitem_filtered didn't had an entry for that state for hosts, only for DOWN and UNREACHABLE states :

```
self.nagitems_filtered = {'services': {'DISASTER': [], 'CRITICAL': [], 'HIGH': [],
    'AVERAGE': [], 'WARNING': [], 'INFORMATION': [], 'UNKNOWN': []},
    'hosts': {'DOWN': [], 'UNREACHABLE': []}}

```

So we added it and we can now use it to store hosts with this state coming from Livestatus servers and display them in the interface. 
We also added the configuration option to filter out UNKNOWN hosts with the current filter system.
 
We are open to any comment, if you feel that some changes need to be made or if you would like things to be handled differently, feel free to let us know and we will adjust accordingly.
 
Best regards,
Bastien from Shinken Solutions
