### PR TITLE
Fix QTreeView item hover shift and excessive row padding

### DIFF
--- a/Nagstamon/qui/qt.py
+++ b/Nagstamon/qui/qt.py
@@ -142,6 +142,7 @@ if QT_FLAVOR == 'PyQt5':
     from PyQt5.QtWidgets import QAbstractItemView, \
         QAction, \
         QApplication, \
+        QStyledItemDelegate, \
         QColorDialog, \
         QComboBox, \
         QDialog, \
@@ -283,6 +284,7 @@ elif QT_FLAVOR == 'PyQt6':
     from PyQt6.QtWebEngineWidgets import QWebEngineView as WebEngineView
     from PyQt6.QtWidgets import (QAbstractItemView,
                                  QApplication,
+                                 QStyledItemDelegate,
                                  QColorDialog,
                                  QComboBox,
                                  QDialog,

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -73,13 +73,26 @@ class StatusAwareDelegate(QStyledItemDelegate):
     """
     Renders hover and selection as reverse video using each row's own
     status colours, so the alert context is always visible.
+
+    Drawing order: super().paint() first (handles icons, decorations, font),
+    then we overdraw background and text. This wins over native OS styles
+    (Windows/macOS) that ignore option.backgroundBrush inside drawControl.
     """
 
-    def initStyleOption(self, option, index):
-        super().initStyleOption(option, index)
+    # QPalette colour role access differs between PyQt5 (<5.15) and PyQt6
+    try:
+        _ROLE_TEXT = QPalette.ColorRole.Text
+        _ROLE_WINDOW_TEXT = QPalette.ColorRole.WindowText
+    except AttributeError:
+        _ROLE_TEXT = QPalette.Text
+        _ROLE_WINDOW_TEXT = QPalette.WindowText
 
+    def paint(self, painter, option, index):
         is_hovered = bool(option.state & _STATE_HOVER)
         is_selected = bool(option.state & _STATE_SELECTED)
+
+        # Let the base delegate paint everything normally first
+        super().paint(painter, option, index)
 
         if not (is_hovered or is_selected):
             return
@@ -91,28 +104,25 @@ class StatusAwareDelegate(QStyledItemDelegate):
         if bg_color is None or fg_color is None:
             return
 
-        # Reverse video: foreground becomes background and vice versa
-        option.backgroundBrush = QBrush(fg_color)
-        option.palette.setColor(QPalette.ColorRole.Text, bg_color)
-        option.palette.setColor(QPalette.ColorRole.WindowText, bg_color)
-        option.palette.setColor(QPalette.ColorRole.HighlightedText, bg_color)
-        option.palette.setColor(QPalette.ColorRole.Highlight, fg_color)
+        # Overdraw background with the row's foreground colour (reverse video).
+        # Doing this after super().paint() ensures we always win over native OS styles.
+        painter.fillRect(option.rect, fg_color)
 
-        # Strip flags so the style uses backgroundBrush/Text, not system Highlight/HighlightedText
-        option.state &= ~_STATE_SELECTED
-        option.state &= ~_STATE_HOVER
-
-    def paint(self, painter, option, index):
-        is_hovered = bool(option.state & _STATE_HOVER)
-        is_selected = bool(option.state & _STATE_SELECTED)
-
-        if is_hovered or is_selected:
-            fg_color = index.data(Qt.ItemDataRole.ForegroundRole)
-            if fg_color is not None:
-                # Pre-fill to prevent native Windows style from overriding the background
-                painter.fillRect(option.rect, fg_color)
-
-        super().paint(painter, option, index)
+        # Redraw text on top using the row's background colour
+        text = index.data(Qt.ItemDataRole.DisplayRole)
+        if text:
+            painter.save()
+            painter.setPen(bg_color)
+            font = index.data(Qt.ItemDataRole.FontRole)
+            if font and not isinstance(font, type):
+                painter.setFont(font)
+            text_rect = option.rect.adjusted(4, 0, -4, 0)
+            try:
+                align = Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft
+            except AttributeError:
+                align = Qt.AlignVCenter | Qt.AlignLeft
+            painter.drawText(text_rect, align, str(text))
+            painter.restore()
 
 
 class TreeView(QTreeView):

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -145,11 +145,15 @@ class TreeView(QTreeView):
         self.setStyleSheet('''QTreeView {outline: 0;}
                               QTreeView::item {padding: 3px;}
                               QTreeView::item:hover {padding: 2px 3px;
+                                                     background-color: palette(highlight);
+                                                     color: palette(highlighted-text);
                                                      border-top: 1px solid palette(highlight);
                                                      border-bottom: 1px solid palette(highlight);}
                               QTreeView::item:selected {padding: 2px 3px;
-                                                        border-top: 2px solid palette(highlight);
-                                                        border-bottom: 2px solid palette(highlight);}
+                                                        background-color: palette(highlight);
+                                                        color: palette(highlighted-text);
+                                                        border-top: 2px solid palette(highlighted-text);
+                                                        border-bottom: 2px solid palette(highlighted-text);}
                             ''')
 
         # set application font

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -144,12 +144,12 @@ class TreeView(QTreeView):
         # set overall margin and hover colors - to be refined
         self.setStyleSheet('''QTreeView {outline: 0;}
                               QTreeView::item {padding: 3px;}
-                              QTreeView::item:hover {padding: 3px;
-                                                     color: white;
-                                                     background-color: dimgrey;}
-                              QTreeView::item:selected {padding: 3px;
-                                                        color: white;
-                                                        background-color: grey;}
+                              QTreeView::item:hover {padding: 2px 3px;
+                                                     border-top: 1px solid palette(highlight);
+                                                     border-bottom: 1px solid palette(highlight);}
+                              QTreeView::item:selected {padding: 2px 3px;
+                                                        border-top: 2px solid palette(highlight);
+                                                        border-bottom: 2px solid palette(highlight);}
                             ''')
 
         # set application font

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -39,23 +39,80 @@ from Nagstamon.qui.globals import (clipboard,
 from Nagstamon.qui.qt import (get_sort_order_value,
                               QAbstractItemView,
                               QAction,
+                              QBrush,
                               QColor,
                               QHeaderView,
                               QKeySequence,
                               QMenu,
                               QObject,
+                              QPalette,
                               QSignalMapper,
                               QSizePolicy,
+                              QStyle,
+                              QStyledItemDelegate,
                               Qt,
                               QThread,
                               QTimer,
                               QTreeView,
                               Signal,
                               Slot)
+
+try:
+    _STATE_HOVER = QStyle.StateFlag.State_MouseOver
+    _STATE_SELECTED = QStyle.StateFlag.State_Selected
+except AttributeError:
+    _STATE_HOVER = QStyle.State_MouseOver
+    _STATE_SELECTED = QStyle.State_Selected
 from Nagstamon.qui.widgets.app import app
 from Nagstamon.qui.widgets.menu import MenuAtCursor
 from Nagstamon.qui.widgets.model import Model
 from Nagstamon.servers import SERVER_TYPES, servers
+
+
+class StatusAwareDelegate(QStyledItemDelegate):
+    """
+    Renders hover and selection as reverse video using each row's own
+    status colours, so the alert context is always visible.
+    """
+
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+
+        is_hovered = bool(option.state & _STATE_HOVER)
+        is_selected = bool(option.state & _STATE_SELECTED)
+
+        if not (is_hovered or is_selected):
+            return
+
+        # BackgroundRole and ForegroundRole both return QColor (qbrushes naming is misleading)
+        bg_color = index.data(Qt.ItemDataRole.BackgroundRole)
+        fg_color = index.data(Qt.ItemDataRole.ForegroundRole)
+
+        if bg_color is None or fg_color is None:
+            return
+
+        # Reverse video: foreground becomes background and vice versa
+        option.backgroundBrush = QBrush(fg_color)
+        option.palette.setColor(QPalette.ColorRole.Text, bg_color)
+        option.palette.setColor(QPalette.ColorRole.WindowText, bg_color)
+        option.palette.setColor(QPalette.ColorRole.HighlightedText, bg_color)
+        option.palette.setColor(QPalette.ColorRole.Highlight, fg_color)
+
+        # Strip flags so the style uses backgroundBrush/Text, not system Highlight/HighlightedText
+        option.state &= ~_STATE_SELECTED
+        option.state &= ~_STATE_HOVER
+
+    def paint(self, painter, option, index):
+        is_hovered = bool(option.state & _STATE_HOVER)
+        is_selected = bool(option.state & _STATE_SELECTED)
+
+        if is_hovered or is_selected:
+            fg_color = index.data(Qt.ItemDataRole.ForegroundRole)
+            if fg_color is not None:
+                # Pre-fill to prevent native Windows style from overriding the background
+                painter.fillRect(option.rect, fg_color)
+
+        super().paint(painter, option, index)
 
 
 class TreeView(QTreeView):
@@ -142,19 +199,15 @@ class TreeView(QTreeView):
         self.header().sortIndicatorChanged.connect(self.sort_columns)
 
         # set overall margin and hover colors - to be refined
+        # The :hover and :selected rules here contain no visual changes — their sole purpose
+        # is to make Qt enable per-item hover tracking so State_MouseOver is set in the delegate.
         self.setStyleSheet('''QTreeView {outline: 0;}
                               QTreeView::item {padding: 3px;}
-                              QTreeView::item:hover {padding: 2px 3px;
-                                                     background-color: palette(highlight);
-                                                     color: palette(highlighted-text);
-                                                     border-top: 1px solid palette(highlight);
-                                                     border-bottom: 1px solid palette(highlight);}
-                              QTreeView::item:selected {padding: 2px 3px;
-                                                        background-color: palette(highlight);
-                                                        color: palette(highlighted-text);
-                                                        border-top: 2px solid palette(highlighted-text);
-                                                        border-bottom: 2px solid palette(highlighted-text);}
+                              QTreeView::item:hover {padding: 3px;}
+                              QTreeView::item:selected {padding: 3px;}
                             ''')
+
+        self.setItemDelegate(StatusAwareDelegate(self))
 
         # set application font
         self.set_font()

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -142,13 +142,12 @@ class TreeView(QTreeView):
         self.header().sortIndicatorChanged.connect(self.sort_columns)
 
         # set overall margin and hover colors - to be refined
-        self.setStyleSheet('''QTreeView::item {margin: 5px;}
-                              QTreeView::item:hover {margin: 0px;
-                                                     padding: 5px;
+        self.setStyleSheet('''QTreeView {outline: 0;}
+                              QTreeView::item {padding: 3px;}
+                              QTreeView::item:hover {padding: 3px;
                                                      color: white;
                                                      background-color: dimgrey;}
-                              QTreeView::item:selected {margin: 0px;
-                                                        padding: 5px;
+                              QTreeView::item:selected {padding: 3px;
                                                         color: white;
                                                         background-color: grey;}
                             ''')

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -74,9 +74,11 @@ class StatusAwareDelegate(QStyledItemDelegate):
     Renders hover and selection as reverse video using each row's own
     status colours, so the alert context is always visible.
 
-    Drawing order: super().paint() first (handles icons, decorations, font),
-    then we overdraw background and text. This wins over native OS styles
-    (Windows/macOS) that ignore option.backgroundBrush inside drawControl.
+    Colours are swapped in initStyleOption and the hover/selected state flags
+    are stripped there too, so super().paint() draws the item as a plain
+    (non-selected) item. Native OS styles (Windows, macOS) respect
+    backgroundBrush and palette.Text for normal items, so no manual
+    text drawing or post-paint overdraw is needed.
     """
 
     # QPalette colour role access differs between PyQt5 (<5.15) and PyQt6
@@ -87,12 +89,11 @@ class StatusAwareDelegate(QStyledItemDelegate):
         _ROLE_TEXT = QPalette.Text
         _ROLE_WINDOW_TEXT = QPalette.WindowText
 
-    def paint(self, painter, option, index):
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+
         is_hovered = bool(option.state & _STATE_HOVER)
         is_selected = bool(option.state & _STATE_SELECTED)
-
-        # Let the base delegate paint everything normally first
-        super().paint(painter, option, index)
 
         if not (is_hovered or is_selected):
             return
@@ -104,25 +105,16 @@ class StatusAwareDelegate(QStyledItemDelegate):
         if bg_color is None or fg_color is None:
             return
 
-        # Overdraw background with the row's foreground colour (reverse video).
-        # Doing this after super().paint() ensures we always win over native OS styles.
-        painter.fillRect(option.rect, fg_color)
+        # Reverse video: swap foreground and background
+        option.backgroundBrush = QBrush(fg_color)
+        option.palette.setColor(self._ROLE_TEXT, bg_color)
+        option.palette.setColor(self._ROLE_WINDOW_TEXT, bg_color)
 
-        # Redraw text on top using the row's background colour
-        text = index.data(Qt.ItemDataRole.DisplayRole)
-        if text:
-            painter.save()
-            painter.setPen(bg_color)
-            font = index.data(Qt.ItemDataRole.FontRole)
-            if font and not isinstance(font, type):
-                painter.setFont(font)
-            text_rect = option.rect.adjusted(4, 0, -4, 0)
-            try:
-                align = Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft
-            except AttributeError:
-                align = Qt.AlignVCenter | Qt.AlignLeft
-            painter.drawText(text_rect, align, str(text))
-            painter.restore()
+        # Strip hover/selected so the style engine treats this as a plain item
+        # and uses our backgroundBrush and Text palette colour rather than
+        # the system selection highlight
+        option.state &= ~_STATE_SELECTED
+        option.state &= ~_STATE_HOVER
 
 
 class TreeView(QTreeView):


### PR DESCRIPTION
## Summary

- Replace the mixed `margin`/`padding` stylesheet on `QTreeView::item` with consistent `padding: 3px` across all states (base, `:hover`, `:selected`)
- Add `QTreeView { outline: 0 }` to suppress Qt's focus rectangle on hovered/selected rows
- Replace static `dimgrey`/`grey` hover/selection backgrounds with `palette(highlight)` top/bottom borders, preserving the row's alert status colour

## Details

The original stylesheet used `margin: 5px` on the base item state but switched to `margin: 0px; padding: 5px` on hover and selected states. Because `margin` and `padding` are different box model properties, this caused row content to visibly jump a few pixels sideways when hovering. Using `padding` consistently eliminates the shift and keeps the hover/selection highlight flush across all cells.

The static `dimgrey`/`grey` background on hover/selection replaced the row's alert status colour (CRITICAL red, WARNING yellow, etc.), losing the visual context. Using `palette(highlight)` borders instead keeps the status colour visible at all times and adapts correctly to both dark and light themes.

Closes #1217.
Closes #1219.