### PR TITLE
Potential fix for code scanning alert no. 3: Use of insecure SSL/TLS version

### DIFF
--- a/Nagstamon/servers/Livestatus.py
+++ b/Nagstamon/servers/Livestatus.py
@@ -65,6 +65,10 @@ def get_socket(address: 'tuple(str, str)', protocol: str, ignore_cert: bool, cus
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
         if protocol.endswith('s'):
             context = ssl.create_default_context()
+            if hasattr(context, 'minimum_version') and hasattr(ssl, 'TLSVersion'):
+                context.minimum_version = ssl.TLSVersion.TLSv1_2
+            else:
+                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
             context.check_hostname = not ignore_cert
             context.verify_mode = ssl.VerifyMode.CERT_NONE if ignore_cert else ssl.VerifyMode.CERT_REQUIRED
         


### PR DESCRIPTION
Potential fix for [https://github.com/HenriWahl/Nagstamon/security/code-scanning/3](https://github.com/HenriWahl/Nagstamon/security/code-scanning/3)

To fix this safely without changing intended functionality, keep using `ssl.create_default_context()` (good defaults for cert validation), but explicitly enforce TLS 1.2+ on the created context before wrapping the socket.

Best concrete change in `Nagstamon/servers/Livestatus.py`:
- In `get_socket(...)`, right after `context = ssl.create_default_context()`, set:
  - `context.minimum_version = ssl.TLSVersion.TLSv1_2` when available.
  - Add a compatibility fallback for older Python versions by disabling TLSv1 and TLSv1.1 with `context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1`.
- Leave existing hostname/certificate behavior and custom CA loading logic unchanged.

This single change addresses both reported variants (TLSv1 and TLSv1_1).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
