### PR TITLE
Clear row selection after context menu action completes

### DIFF
--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -731,6 +731,9 @@ class TreeView(QTreeView):
                     not method.__name__ == 'action_recheck' and \
                     not method.__name__ == 'action_archive_event':
                 self.action_menu_clicked.emit()
+            # clear the right-click selection so the row doesn't remain
+            # visually highlighted after the action completes
+            self.clearSelection()
 
         return decoration_function
 


### PR DESCRIPTION
## Summary

After a right-click, Qt's default `mousePressEvent` selects the row under the cursor. Without explicit clearing, that selection persists after the action completes and the row remains visually highlighted (reverse-video) until the user right-clicks another row or a full model refresh occurs.

The fix adds a single `clearSelection()` call at the end of `action_response_decorator`, after the action method has already captured `selectedIndexes()` and emitted its signals — so no action loses access to the selection it needs.

## Behaviour

- Right-click → Recheck: row highlight clears immediately after the action fires
- Right-click → any other action: same — selection clears after action completes
- Menu dismissed without selecting an action: selection is **not** cleared (the decorator only runs on actual action invocation)

## Test plan

- [x] Right-click a row → Recheck → row should no longer remain highlighted
- [x] Right-click → Acknowledge / Downtime → dialogs open with correct data, row de-highlights after
- [x] Dismiss the context menu without choosing an action → no change in selection state
- [x] Test in fullscreen and windowed modes
- [x] Cross-platform: Linux (KDE + GNOME), Windows, macOS

Follows on from #1222.