### PR TITLE
[#491] Add host group filtering for IcingaWeb2 and Icinga2API

### DIFF
--- a/Nagstamon/qui/dialogs/__init__.py
+++ b/Nagstamon/qui/dialogs/__init__.py
@@ -68,6 +68,7 @@ class Dialogs(QObject):
         # check if special widgets have to be shown
         self.server.edited.connect(self.settings.toggle_zabbix_widgets)
         self.server.edited.connect(self.settings.toggle_op5monitor_widgets)
+        self.server.edited.connect(self.settings.toggle_groups_filter_widgets)
         self.server.edited.connect(self.settings.toggle_expire_time_widgets)
 
     def initialize_dialog_action(self, dialog):

--- a/Nagstamon/qui/dialogs/settings.py
+++ b/Nagstamon/qui/dialogs/settings.py
@@ -355,6 +355,11 @@ class DialogSettings(Dialog):
                                    self.window.input_lineedit_re_groups_pattern,
                                    self.window.input_checkbox_re_groups_reverse]
 
+        # same groups filter widgets, additionally shown for Icinga server types (issue #491)
+        self.GROUPS_FILTER_WIDGETS = [self.window.input_checkbox_re_groups_enabled,
+                                      self.window.input_lineedit_re_groups_pattern,
+                                      self.window.input_checkbox_re_groups_reverse]
+
         # ...and another...
         self.EXPIRE_TIME_WIDGETS = [self.window.input_checkbox_defaults_acknowledge_expire,
                                     self.window.label_expire_in,
@@ -451,6 +456,7 @@ class DialogSettings(Dialog):
         # hide them and thus be able to fix size if no extra Zabbix/Op5Monitor/IcingaWeb2 widgets are shown
         self.toggle_zabbix_widgets()
         self.toggle_op5monitor_widgets()
+        self.toggle_groups_filter_widgets()
         self.toggle_expire_time_widgets()
 
         # tell the world that dialog pops up
@@ -1039,6 +1045,20 @@ class DialogSettings(Dialog):
         else:
             for widget in self.OP5MONITOR_WIDGETS:
                 widget.hide()
+
+    @Slot()
+    def toggle_groups_filter_widgets(self):
+        """
+        additionally show the groups filter widgets for Icinga server types (issue #491).
+        This runs after toggle_op5monitor_widgets() and only ever shows the widgets, so the
+        Op5Monitor logic stays untouched and remains the authority for hiding them.
+        """
+        for server in servers.values():
+            if server.enabled:
+                if server.type in ('Icinga2API', 'IcingaWeb2'):
+                    for widget in self.GROUPS_FILTER_WIDGETS:
+                        widget.show()
+                    break
 
     @Slot()
     def toggle_expire_time_widgets(self):

--- a/Nagstamon/servers/Generic.py
+++ b/Nagstamon/servers/Generic.py
@@ -1080,6 +1080,11 @@ class GenericServer:
                         self.debug(server=self.get_name(), debug='Filter: REGEXP ' + str(host.name))
                     host.visible = False
 
+                if groups_is_filtered_out_by_re(host.groups, conf) is True:
+                    if conf.debug_mode:
+                        self.debug(server=self.get_name(), debug='Filter: REGEXP ' + str(host.name))
+                    host.visible = False
+
                 # The Criticality filter can be used only with centreon objects. Other objects don't have the criticality attribute.
                 if self.type == 'Centreon':
                     if criticality_is_filtered_out_by_re(host.criticality, conf):

--- a/Nagstamon/servers/Icinga2API.py
+++ b/Nagstamon/servers/Icinga2API.py
@@ -68,6 +68,10 @@ class Icinga2APIServer(GenericServer):
             self.new_hosts[service_host] = GenericHost()
             self.new_hosts[service_host].name = service_host
             self.new_hosts[service_host].site = service.site
+        # carry host groups to the host object so host group filtering works for
+        # hosts that are only present because of a faulty service (issue #491)
+        if service.groups and not self.new_hosts[service_host].groups:
+            self.new_hosts[service_host].groups = service.groups
         self.new_hosts[service_host].services[service.name] = service
 
     def _get_status(self):
@@ -110,6 +114,7 @@ class Icinga2APIServer(GenericServer):
                     self.new_hosts[host_name].acknowledged = bool(host['attrs']['acknowledgement'])
                     self.new_hosts[host_name].scheduled_downtime = bool(host['attrs']['downtime_depth'])
                     self.new_hosts[host_name].status_type = {0: "soft", 1: "hard"}[host['attrs']['state_type']]
+                    self.new_hosts[host_name].groups = str(host['attrs'].get('groups', []))
                 del host_name
             del hosts
 
@@ -151,6 +156,8 @@ class Icinga2APIServer(GenericServer):
                 new_service.acknowledged = bool(service['attrs']['acknowledgement'])
                 new_service.scheduled_downtime = bool(service['attrs']['downtime_depth'])
                 new_service.status_type = {0: "soft", 1: "hard"}[service['attrs']['state_type']]
+                # host groups joined from the host object, used for host group filtering (issue #491)
+                new_service.groups = str(service.get('joins', {}).get('host', {}).get('groups', []))
                 self._insert_service_to_hosts(new_service)
             del services
 
@@ -164,10 +171,13 @@ class Icinga2APIServer(GenericServer):
         # dummy return in case all is OK
         return Result()
 
-    def _list_objects(self, object_type, filter):
+    def _list_objects(self, object_type, filter, joins=None):
         """List objects"""
+        params = {"filter": filter}
+        if joins is not None:
+            params["joins"] = joins
         result = self.fetch_url(
-            f'{self.url}/objects/{object_type}?{urllib.parse.urlencode({"filter": filter})}',
+            f'{self.url}/objects/{object_type}?{urllib.parse.urlencode(params)}',
             giveback='raw'
         )
         # purify JSON result of unnecessary control sequence \n
@@ -187,8 +197,11 @@ class Icinga2APIServer(GenericServer):
     def _get_service_events(self):
         """
         Suck faulty service events from API
+
+        Join the host's groups so host group filtering (issue #491) can be applied
+        to services as well, without an extra request.
         """
-        return self._list_objects('services', 'service.state!=ServiceOK')
+        return self._list_objects('services', 'service.state!=ServiceOK', joins='host.groups')
 
     def _get_host_events(self):
         """

--- a/Nagstamon/servers/IcingaWeb2.py
+++ b/Nagstamon/servers/IcingaWeb2.py
@@ -346,9 +346,69 @@ class IcingaWeb2Server(GenericServer):
         # some cleanup
         del jsonraw, error, hosts, services
 
+        # fetch host groups after all hosts and services are known
+        self._fetch_host_groups()
+
         # dummy return in case all is OK
         return Result()
 
+    def _fetch_host_groups(self):
+        """Populate host.groups and service.groups by querying per hostgroup.
+
+        Strategy: 1 request for the group list, then 1 request per group to get its
+        members. Scales with number of groups (typically 20-50), not number of hosts.
+        Only runs when the groups regex filter is enabled.
+        """
+        from Nagstamon.config import conf
+        if not conf.re_groups_enabled or not self.new_hosts:
+            return
+        try:
+            real_to_key = {}
+            for key, obj in self.new_hosts.items():
+                real_to_key[key] = key
+                real_name = getattr(obj, 'real_name', None)
+                if real_name:
+                    real_to_key[real_name] = key
+
+            # fetch list of all hostgroups
+            url = self.monitor_cgi_url + '/monitoring/list/hostgroups?format=json'
+            result = self.fetch_url(url, giveback='raw')
+            jsonraw = result.result.replace('\n', '')
+            if not jsonraw.strip() or jsonraw.lstrip().startswith('<'):
+                return
+            all_groups = []
+            for item in json.loads(jsonraw):
+                h = dict(item.items())
+                g = h.get('hostgroup_name') or h.get('hostgroup_alias') or h.get('hostgroup', '')
+                if g:
+                    all_groups.append(g)
+
+            # for each group fetch its member hosts
+            for group in all_groups:
+                url = (self.monitor_cgi_url + '/monitoring/list/hosts?' +
+                       urllib.parse.urlencode([('hostgroup', group), ('format', 'json')]))
+                result = self.fetch_url(url, giveback='raw')
+                jsonraw = result.result.replace('\n', '')
+                if not jsonraw.strip() or jsonraw.lstrip().startswith('<'):
+                    continue
+                for host in json.loads(jsonraw):
+                    h = dict(host.items())
+                    host_name = h.get('host_name') or h.get('host', '')
+                    matched = real_to_key.get(host_name)
+                    if not matched:
+                        continue
+                    host_obj = self.new_hosts[matched]
+                    if group not in host_obj.groups:
+                        host_obj.groups = (host_obj.groups + ', ' + group) if host_obj.groups else group
+
+            # propagate host groups to services so service-level filter works
+            for host_obj in self.new_hosts.values():
+                if host_obj.groups:
+                    for service in host_obj.services.values():
+                        service.groups = host_obj.groups
+        except Exception:
+            import traceback
+            traceback.print_exc(file=sys.stdout)
 
     def _set_recheck(self, host, service):
         # First retrieve the info page for this host/service


### PR DESCRIPTION
- IcingaWeb2: fetch host groups via separate per-hostgroup requests, propagate groups to services for service-level filtering
- Icinga2API: populate host.groups from API response
- Settings: show groups filter widget for IcingaWeb2 and Icinga2API

Assisted-by: Claude:sonnet-4-6

(Resolving #491)