### PR TITLE
fix: Checkmk Multisite always OK due to empty Basic Auth context (#1077)

### DIFF
--- a/Nagstamon/servers/Multisite.py
+++ b/Nagstamon/servers/Multisite.py
@@ -126,6 +126,19 @@ class MultisiteServer(GenericServer):
                 'PEND':    'PENDING',
             }
 
+        # Establish a real interactive session cookie before any Basic Auth
+        # request is sent. On some Checkmk setups a Basic-Auth-authenticated
+        # request is answered in a context that returns *no* view rows (empty
+        # result) while the interactive session returns all rows. This made
+        # Nagstamon show "OK" although host/service problems existed
+        # (see https://github.com/HenriWahl/Nagstamon/issues/1077).
+        # Logging in via login.py with the Basic Auth header suppressed yields
+        # a proper interactive session that returns the complete data.
+        if self.authentication != 'web' and \
+                self.session is not None and \
+                not self._is_auth_in_cookies():
+            self._get_cookie_login()
+
         # Function overrides for Checkmk 2.3+
         version = self._get_version()
         if version >= [2, 3]:
@@ -232,8 +245,21 @@ class MultisiteServer(GenericServer):
                      'filled_in' :' login'}
         # get cookie from login page via url retrieving as with other urls
         try:
-            # login and get cookie
-            self.fetch_url(self.monitor_url + '/login.py', cgi_data=login_data, multipart=True)
+            # Temporarily suppress the Basic Auth header for the login request.
+            # If Basic Auth is sent along, some Checkmk setups short-circuit the
+            # login and keep the session in a Basic-Auth context that returns no
+            # view rows (see issue #1077). Without it, login.py establishes a
+            # proper interactive session cookie that returns the full data.
+            saved_auth = None
+            if self.session is not None:
+                saved_auth = self.session.auth
+                self.session.auth = None
+            try:
+                # login and get cookie
+                self.fetch_url(self.monitor_url + '/login.py', cgi_data=login_data, multipart=True)
+            finally:
+                if self.session is not None:
+                    self.session.auth = saved_auth
         except:
             self.error(sys.exc_info())
 


### PR DESCRIPTION
## Summary

Fixes #1077

On some Checkmk setups Nagstamon permanently shows **OK** even though there are host/service problems. This PR makes the Checkmk Multisite backend establish a real interactive session, so the views return the actual data.

## Root cause

For the same user, the two authentication paths return different data:

- **Basic Auth context** → the `nagstamon_hosts` / `nagstamon_svc` views return **only the header row, no data** (a valid but empty `output_format=python` response).
- **Interactive cookie session** (via `login.py`) → the views return **all** rows.

Because Nagstamon sets the Basic Auth header on *every* request (`session.auth = (user, pw)`), it stayed in the empty Basic Auth context:

1. The first view request is sent with Basic Auth and returns a valid python list with **0 rows** (not HTML), so the existing HTML-based cookie-login fallback never triggers.
2. Even the `login.py` call carried the Basic Auth header, so Checkmk did not issue a proper interactive session cookie.

Result: 0 problems counted → `all_ok = True` → tray icon stays green.

## Fix

- `_get_cookie_login()` now temporarily clears `session.auth` for the `login.py` request (restored afterwards, also on error), so Checkmk creates a real interactive session cookie instead of keeping the empty Basic Auth context.
- `init_http()` performs this interactive login once, before any Basic Auth request can pin the session to the empty context, and only when no auth cookie is present yet (no extra login per poll cycle).

Once a valid interactive cookie exists, sending Basic Auth alongside is harmless, so setups that rely on Basic Auth (e.g. at a reverse proxy) keep working.

## How it was diagnosed / reproduced

Testing the exact Nagstamon code path against a real Checkmk server:

| Request variant (same user, same URL) | Result |
| --- | --- |
| Basic Auth (as Nagstamon did) | **0 rows** (~298 bytes) |
| Interactive `login.py` login, then fetch | **8828 rows** (~2 MB) |

This also matched a network capture: with Basic Auth only a few response packets were transferred, while the browser (interactive session) transferred thousands of packets for the full list — i.e. the server really sent an empty result, it was not a parsing problem.

## Testing

Verified live against a Checkmk Pro 2.4.0p31 server via the real Nagstamon code path:

- **Before:** `all_ok = True`, 0 hosts, 0 problems.
- **After:** 8828 hosts, ~11,000 problems (DOWN / CRITICAL / WARNING / UNKNOWN), stable across multiple poll cycles.
- Confirmed in the running GUI: problems are now displayed correctly.