### PR TITLE
Fix : IcingaDBWeb causing crashes to nagstamon

### DIFF
--- a/Nagstamon/servers/IcingaDBWeb.py
+++ b/Nagstamon/servers/IcingaDBWeb.py
@@ -128,11 +128,13 @@ class IcingaDBWebServer(GenericServer):
                 if login.error == '' and login.status_code == 200:
                     form = login.result.find('form')
                     form_inputs = {}
-                    for form_input in ('redirect', 'formUID', 'CSRFToken', 'btn_submit'):
-                        if form is not None and not form.find('input', {'name': form_input}) is None:
-                            form_inputs[form_input] = form.find('input', {'name': form_input})['value']
-                        else:
-                            form_inputs[form_input] = ''
+                    for form_input in ('redirect', 'formUID', 'CSRFToken', 'btn_submit', 'uid', 'submit_login'):
+                        form_field_value = ''
+                        if form is not None:
+                            form_field = form.find('input', {'name': form_input})
+                            if form_field is not None and form_field.has_attr('value'):
+                                form_field_value = form_field['value']
+                        form_inputs[form_input] = form_field_value
                     form_inputs['username'] = self.username
                     form_inputs['password'] = self.password
 


### PR DESCRIPTION
This pull request updates the login form handling in the `init_http` method of `IcingaDBWeb.py` to improve compatibility with additional form fields and handle missing values more robustly.

This fixes the crash issue when trying to access an Icinga host using the IcingaDB Web module.

The fix targets Icinga Web 2 version 2.14 and higher, where the issue was introduced. Older versions remain compatible and are still working.

**Login form parsing improvements:**

* The list of expected form input fields has been expanded to include `uid` and `submit_login`, in addition to the existing fields.
* The code now checks for the presence of each input field and its `value` attribute before assigning it, defaulting to an empty string if not found. This makes the parsing more robust against missing or incomplete form fields.

Ref issue: #1235

Happy to help.