### PR TITLE
macOS: one-dir app bundle, declared minimum macOS version, build on macos-26

### DIFF
--- a/.github/workflows/build-release-latest.yml
+++ b/.github/workflows/build-release-latest.yml
@@ -9,6 +9,10 @@ on:
 
 env:
   python_win_version: 3.14.7
+  python_macos_version: 3.14.7
+  # oldest macOS release the app bundle is built for - verified after every macOS build by
+  # build/macos/check_deployment_target.py
+  MACOSX_DEPLOYMENT_TARGET: '13.0'
   repo_dir: nagstamon-jekyll/docs/repo
   cr_image: ghcr.io/henriwahl/build-nagstamon
   # release type this file is used for
@@ -158,15 +162,23 @@ jobs:
 
   macos-intel:
     # according to https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+    # macOS 26 is only available for arm64 runners, so the Intel build stays on macOS 15
     runs-on: macos-15-intel
     needs: test
     steps:
       - uses: actions/checkout@v7
+      # the runner's own python3 is not pinned and differs between the runner images -
+      # its deployment target ends up in the app bundle, so it has to be reproducible
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '${{ env.python_macos_version }}'
       - run : brew install create-dmg
-      - run: pip3 install --no-warn-script-location --break-system-packages -r build/requirements/macos.txt
+      - run: pip3 install --no-warn-script-location -r build/requirements/macos.txt
       - run: cd ${{ github.workspace }}/build; python3 build.py
         env:
           PYTHONPATH: ${{ github.workspace }}
+      # the promised minimum macOS version has to be verified, not hoped for
+      - run: python3 build/macos/check_deployment_target.py build/Nagstamon_*_Staging_DMG/Nagstamon.app
       - uses: actions/upload-artifact@v7
         with:
           path: build/dist/*.dmg
@@ -175,15 +187,22 @@ jobs:
           name: ${{ github.job }}
 
   macos-arm:
-    runs-on: macos-14
+    runs-on: macos-26
     needs: test
     steps:
       - uses: actions/checkout@v7
+      # the runner's own python3 is not pinned and differs between the runner images -
+      # its deployment target ends up in the app bundle, so it has to be reproducible
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '${{ env.python_macos_version }}'
       - run : brew install create-dmg
-      - run: pip3 install --no-warn-script-location --break-system-packages -r build/requirements/macos.txt
+      - run: pip3 install --no-warn-script-location -r build/requirements/macos.txt
       - run: cd ${{ github.workspace }}/build; python3 build.py
         env:
           PYTHONPATH: ${{ github.workspace }}
+      # the promised minimum macOS version has to be verified, not hoped for
+      - run: python3 build/macos/check_deployment_target.py build/Nagstamon_*_Staging_DMG/Nagstamon.app
       - uses: actions/upload-artifact@v7
         with:
           path: build/dist/*.dmg

--- a/.github/workflows/build-release-stable.yml
+++ b/.github/workflows/build-release-stable.yml
@@ -5,6 +5,10 @@ on:
 
 env:
   python_win_version: 3.14.3
+  python_macos_version: 3.14.3
+  # oldest macOS release the app bundle is built for - verified after every macOS build by
+  # build/macos/check_deployment_target.py
+  MACOSX_DEPLOYMENT_TARGET: '13.0'
   repo_dir: nagstamon-jekyll/docs/repo
   cr_image: ghcr.io/henriwahl/build-nagstamon
   # release type this file is used for
@@ -154,15 +158,23 @@ jobs:
 
   macos-intel:
     # according to https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+    # macOS 26 is only available for arm64 runners, so the Intel build stays on macOS 15
     runs-on: macos-15-intel
     needs: test
     steps:
       - uses: actions/checkout@v6
+      # the runner's own python3 is not pinned and differs between the runner images -
+      # its deployment target ends up in the app bundle, so it has to be reproducible
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '${{ env.python_macos_version }}'
       - run : brew install create-dmg
-      - run: pip3 install --no-warn-script-location --break-system-packages -r build/requirements/macos.txt
+      - run: pip3 install --no-warn-script-location -r build/requirements/macos.txt
       - run: cd ${{ github.workspace }}/build; python3 build.py
         env:
           PYTHONPATH: ${{ github.workspace }}
+      # the promised minimum macOS version has to be verified, not hoped for
+      - run: python3 build/macos/check_deployment_target.py build/Nagstamon_*_Staging_DMG/Nagstamon.app
       - uses: actions/upload-artifact@v7
         with:
           path: build/dist/*.dmg
@@ -171,15 +183,22 @@ jobs:
           name: ${{ github.job }}
 
   macos-arm:
-    runs-on: macos-14
+    runs-on: macos-26
     needs: test
     steps:
       - uses: actions/checkout@v6
+      # the runner's own python3 is not pinned and differs between the runner images -
+      # its deployment target ends up in the app bundle, so it has to be reproducible
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '${{ env.python_macos_version }}'
       - run : brew install create-dmg
-      - run: pip3 install --no-warn-script-location --break-system-packages -r build/requirements/macos.txt
+      - run: pip3 install --no-warn-script-location -r build/requirements/macos.txt
       - run: cd ${{ github.workspace }}/build; python3 build.py
         env:
           PYTHONPATH: ${{ github.workspace }}
+      # the promised minimum macOS version has to be verified, not hoped for
+      - run: python3 build/macos/check_deployment_target.py build/Nagstamon_*_Staging_DMG/Nagstamon.app
       - uses: actions/upload-artifact@v7
         with:
           path: build/dist/*.dmg

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ It is inspired by Nagios Checker for Firefox – just without an open Firefox wi
 
 Nagstamon is released under the GPLv2 and free to use and modify.
 
-Nagstamon is written in Python 3 and uses the Qt 5/6 GUI toolkit which makes it very portable. It has been tested successfully on latest Ubuntu, Debian, Windows, NetBSD, OpenBSD, FreeBSD and MacOS X.
+Nagstamon is written in Python 3 and uses the Qt 5/6 GUI toolkit which makes it very portable. It has been tested successfully on latest Ubuntu, Debian, Windows, NetBSD, OpenBSD, FreeBSD and macOS.
 It works with GNOME, KDE, Windows and macOS desktops.
+
+The macOS builds require **macOS 13 Ventura or newer**, because that is the oldest release the shipped Qt 6.11 binaries support. There are separate disk images for Apple Silicon (`ARM`) and Intel (`Intel`) - the Qt binaries are not available as universal binaries, so one image cannot serve both.
 
 Successfully tested monitors include:
 

--- a/build/build.py
+++ b/build/build.py
@@ -48,6 +48,11 @@ ARCH_WINDOWS_OPTS = {'32': ('win32', 'win32', '', 'x86'),
 ARCH_MACOS = platform.machine()
 ARCH_MACOS_NAMES = {'x86_64': 'Intel',
                     'arm64': 'ARM'}
+ARCH_MACOS_NAME = ARCH_MACOS_NAMES.get(ARCH_MACOS, ARCH_MACOS)
+
+# oldest macOS release the app bundle is built for - the shipped Qt binaries of
+# pyqt6-qt6 6.10 and newer require macOS 13, so anything lower would not run anyway
+MACOS_DEPLOYMENT_TARGET = '13.0'
 
 PYTHON_VERSION = '{0}.{1}'.format(sys.version_info[0],
                                   sys.version_info[1])
@@ -188,6 +193,15 @@ def package_windows():
         subprocess.run(['powershell.exe', '../windows/code_signing.ps1', '*.exe'])
 
 
+def run_or_die(command, error_message):
+    """
+        run a shell command and stop the build if it fails - a broken build must not end
+        up being uploaded as if everything went fine
+    """
+    if subprocess.call([command], shell=True) != 0:
+        sys.exit(f'{error_message}: {command}')
+
+
 def package_macos():
     """
         execute steps necessary for compilation of MacOS X binaries and .dmg file
@@ -195,8 +209,18 @@ def package_macos():
     # can't pass --version to pyinstaller in spec mode, so export as env var
     os.environ['NAGSTAMON_VERSION'] = VERSION
 
-    # create one-file .app bundle by pyinstaller
-    subprocess.call(['pyinstaller --noconfirm macos/nagstamon.spec'], shell=True)
+    # the spec file uses it for LSMinimumSystemVersion
+    os.environ.setdefault('MACOSX_DEPLOYMENT_TARGET', MACOS_DEPLOYMENT_TARGET)
+
+    # create one-dir .app bundle by pyinstaller
+    run_or_die('pyinstaller --noconfirm macos/nagstamon.spec',
+               'pyinstaller failed')
+
+    # sign the bundle ad-hoc - this is no replacement for a Developer ID signature and
+    # notarization, but arm64 binaries need a valid signature to be startable at all and
+    # signing the finished bundle in one go keeps it consistent
+    run_or_die('codesign --force --deep --sign - dist/Nagstamon.app',
+               'ad-hoc code signing failed')
 
     # create staging DMG folder for later compressing of DMG
     shutil.rmtree(f'Nagstamon_{VERSION}_Staging_DMG/', ignore_errors=True)
@@ -205,25 +229,25 @@ def package_macos():
     shutil.move('dist/Nagstamon.app', f'Nagstamon_{VERSION}_Staging_DMG/Nagstamon.app')
 
     # copy icon to staging folder
-    shutil.copy('../Nagstamon/resources/nagstamon.ico', 'nagstamon.ico'.format(VERSION))
+    shutil.copy('../Nagstamon/resources/nagstamon.icns', 'nagstamon.icns')
 
     # cleanup before new images get created
     for dmg_file in glob.iglob('*.dmg'):
         os.unlink(dmg_file)
 
-    # create dmg file with create-dmg insttaled via brew
-    subprocess.call([f'create-dmg '
-                     f'--volname "Nagstamon {VERSION}" '
-                     f'--volicon "nagstamon.ico" '
-                     f'--window-pos 400 300 '
-                     f'--window-size 600 320 '
-                     f'--icon-size 100 '
-                     f'--icon "Nagstamon.app" 175 110 '
-                     f'--hide-extension "Nagstamon.app" '
-                     f'--app-drop-link 425 110 '
-                     f'"dist/Nagstamon-{VERSION}-{ARCH_MACOS_NAMES[ARCH_MACOS]}.dmg" '
-                     f'Nagstamon_{VERSION}_Staging_DMG/'
-                     ], shell=True)
+    # create dmg file with create-dmg installed via brew
+    run_or_die(f'create-dmg '
+               f'--volname "Nagstamon {VERSION}" '
+               f'--volicon "nagstamon.icns" '
+               f'--window-pos 400 300 '
+               f'--window-size 600 320 '
+               f'--icon-size 100 '
+               f'--icon "Nagstamon.app" 175 110 '
+               f'--hide-extension "Nagstamon.app" '
+               f'--app-drop-link 425 110 '
+               f'"dist/Nagstamon-{VERSION}-{ARCH_MACOS_NAME}.dmg" '
+               f'Nagstamon_{VERSION}_Staging_DMG/',
+               'create-dmg failed')
 
 
 def package_linux_deb():

--- a/build/macos/check_deployment_target.py
+++ b/build/macos/check_deployment_target.py
@@ -65,6 +65,35 @@ def get_minimum_os_version(path):
     return max(versions) if versions else None
 
 
+def get_declared_version(bundle):
+    """
+        return the minimum macOS version the bundle declares in its Info.plist as tuple
+        of ints
+
+        the ways this can go wrong end in a message instead of a traceback, because both
+        of them are plausible: a shell glob which did not match any staging directory is
+        passed on as a literal path, and a bundle might be built without the key
+    """
+    plist_path = bundle / 'Contents' / 'Info.plist'
+    try:
+        with plist_path.open('rb') as file:
+            plist = plistlib.load(file)
+    except OSError as error:
+        sys.exit(f'cannot read {plist_path}: {error}')
+    except plistlib.InvalidFileException as error:
+        sys.exit(f'cannot parse {plist_path}: {error}')
+
+    if 'LSMinimumSystemVersion' not in plist:
+        sys.exit(f'{plist_path} does not contain LSMinimumSystemVersion - the bundle does '
+                 f'not declare a minimum macOS version at all')
+
+    declared = plist['LSMinimumSystemVersion']
+    try:
+        return tuple(int(x) for x in str(declared).split('.'))
+    except ValueError:
+        sys.exit(f'{plist_path} declares an unusable LSMinimumSystemVersion {declared!r}')
+
+
 def collect_versions(bundle):
     """
         return a dict of bundle-relative path to required minimum macOS version for every
@@ -88,8 +117,7 @@ def main():
         sys.exit(f'usage: {sys.argv[0]} <path to Nagstamon.app>')
 
     bundle = Path(sys.argv[1])
-    with (bundle / 'Contents' / 'Info.plist').open('rb') as file:
-        declared = tuple(int(x) for x in plistlib.load(file)['LSMinimumSystemVersion'].split('.'))
+    declared = get_declared_version(bundle)
 
     print(f'{bundle.name} declares LSMinimumSystemVersion {version_string(declared)}')
 

--- a/build/macos/check_deployment_target.py
+++ b/build/macos/check_deployment_target.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Verify that no Mach-O binary inside a macOS app bundle requires a newer macOS than the
+bundle claims in LSMinimumSystemVersion.
+
+The wheel tags of the dependencies are not trustworthy - pyqt6-qt6 still tags its arm64
+wheel macosx_11_0 while the binaries inside require macOS 13. The Python interpreter the
+bundle is built with matters just as much: a Homebrew Python built on macOS 26 drags the
+whole bundle up to macOS 26. Without this check such a change goes unnoticed until users
+on older systems get a dyld error.
+
+Usage: check_deployment_target.py <path to Nagstamon.app>
+"""
+
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+# how many offending files to list before summing up the rest
+MAX_REPORTED_FILES = 15
+
+# Mach-O and universal binary magic numbers
+MACHO_MAGIC = (b'\xcf\xfa\xed\xfe', b'\xce\xfa\xed\xfe',
+               b'\xca\xfe\xba\xbe', b'\xbe\xba\xfe\xca')
+
+
+def version_string(version):
+    """
+        turn a version tuple back into a printable string
+    """
+    return '.'.join(str(x) for x in version)
+
+
+def get_minimum_os_version(path):
+    """
+        return the minimum macOS version a Mach-O file requires as tuple of ints,
+        or None if the file carries no version information
+
+        both load commands which can carry it are evaluated: LC_BUILD_VERSION has a
+        'minos' field, the older LC_VERSION_MIN_MACOSX a 'version' one - the same field
+        name is also used by LC_ID_DYLIB and LC_LOAD_DYLIB for something entirely
+        different, so the current load command has to be tracked
+    """
+    try:
+        output = subprocess.run(['otool', '-l', str(path)],
+                                capture_output=True,
+                                text=True,
+                                check=False).stdout
+    except OSError:
+        return None
+
+    versions = []
+    command = None
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('cmd '):
+            command = stripped.split(None, 1)[1]
+        elif (command == 'LC_BUILD_VERSION' and stripped.startswith('minos ')) or \
+                (command == 'LC_VERSION_MIN_MACOSX' and stripped.startswith('version ')):
+            try:
+                versions.append(tuple(int(x) for x in stripped.split()[1].split('.')))
+            except ValueError:
+                pass
+    return max(versions) if versions else None
+
+
+def collect_versions(bundle):
+    """
+        return a dict of bundle-relative path to required minimum macOS version for every
+        Mach-O file inside the given bundle
+    """
+    versions = dict()
+    for path in bundle.rglob('*'):
+        if not path.is_file() or path.is_symlink():
+            continue
+        with path.open('rb') as file:
+            if file.read(4) not in MACHO_MAGIC:
+                continue
+        minimum = get_minimum_os_version(path)
+        if minimum:
+            versions[path.relative_to(bundle)] = minimum
+    return versions
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(f'usage: {sys.argv[0]} <path to Nagstamon.app>')
+
+    bundle = Path(sys.argv[1])
+    with (bundle / 'Contents' / 'Info.plist').open('rb') as file:
+        declared = tuple(int(x) for x in plistlib.load(file)['LSMinimumSystemVersion'].split('.'))
+
+    print(f'{bundle.name} declares LSMinimumSystemVersion {version_string(declared)}')
+
+    versions = collect_versions(bundle)
+    if not versions:
+        sys.exit('no Mach-O files with version information found - wrong path?')
+
+    effective = max(versions.values())
+    print(f'checked {len(versions)} Mach-O files, '
+          f'they need at least macOS {version_string(effective)}')
+
+    too_new = sorted((version, path) for path, version in versions.items() if version > declared)
+    if not too_new:
+        print('all of them run on the declared minimum macOS version')
+        return
+
+    print(f'\n{len(too_new)} of them require a newer macOS than the bundle claims:')
+    for version, path in reversed(too_new[-MAX_REPORTED_FILES:]):
+        print(f'  {version_string(version)}  {path}')
+    if len(too_new) > MAX_REPORTED_FILES:
+        print(f'  ... and {len(too_new) - MAX_REPORTED_FILES} more')
+
+    sys.exit(f'\nThe bundle really needs macOS {version_string(effective)}. Either raise '
+             f'LSMinimumSystemVersion or build against dependencies - the Python build '
+             f'included - which still support macOS {version_string(declared)}.')
+
+
+if __name__ == '__main__':
+    main()

--- a/build/macos/check_deployment_target.py
+++ b/build/macos/check_deployment_target.py
@@ -25,6 +25,20 @@ MACHO_MAGIC = (b'\xcf\xfa\xed\xfe', b'\xce\xfa\xed\xfe',
                b'\xca\xfe\xba\xbe', b'\xbe\xba\xfe\xca')
 
 
+# how many components a version is padded to, so that a bundle declaring '13' and a
+# binary requiring '13.0.0' are recognized as the same version - a plain tuple comparison
+# would consider the shorter one smaller
+VERSION_COMPONENTS = 3
+
+
+def parse_version(text):
+    """
+        turn a version string into a padded tuple of ints
+    """
+    version = tuple(int(x) for x in text.split('.'))
+    return version + (0,) * (VERSION_COMPONENTS - len(version))
+
+
 def version_string(version):
     """
         turn a version tuple back into a printable string
@@ -59,7 +73,7 @@ def get_minimum_os_version(path):
         elif (command == 'LC_BUILD_VERSION' and stripped.startswith('minos ')) or \
                 (command == 'LC_VERSION_MIN_MACOSX' and stripped.startswith('version ')):
             try:
-                versions.append(tuple(int(x) for x in stripped.split()[1].split('.')))
+                versions.append(parse_version(stripped.split()[1]))
             except ValueError:
                 pass
     return max(versions) if versions else None
@@ -89,7 +103,7 @@ def get_declared_version(bundle):
 
     declared = plist['LSMinimumSystemVersion']
     try:
-        return tuple(int(x) for x in str(declared).split('.'))
+        return parse_version(str(declared))
     except ValueError:
         sys.exit(f'{plist_path} declares an unusable LSMinimumSystemVersion {declared!r}')
 

--- a/build/macos/nagstamon.spec
+++ b/build/macos/nagstamon.spec
@@ -2,50 +2,79 @@
 
 import os
 
-block_cipher = None
+try:
+    from PyInstaller.utils.hooks import collect_submodules
+    # same as the --collect-submodules gssapi.raw of the Linux build - Nagstamon imports
+    # gssapi.raw.cython_converters on macOS to get Kerberos support compiled in
+    hidden_imports = collect_submodules('gssapi.raw')
+except Exception:
+    hidden_imports = []
+
+# oldest macOS release Nagstamon is built for - has to match the minimum deployment target
+# of the shipped Qt binaries, which the CI verifies after the build
+minimum_system_version = os.environ.get('MACOSX_DEPLOYMENT_TARGET', '13.0')
+
+# macOS 26 draws applications in the new Liquid Glass design which Qt does not fully
+# support yet - UIDesignRequiresCompatibility keeps the look and metrics of the earlier
+# releases. Opt-in via environment variable to be able to build and compare both.
+ui_compatibility = os.environ.get('NAGSTAMON_MACOS_UI_COMPAT', '').lower() in ('1', 'true', 'yes')
 
 a = Analysis(['../../nagstamon.py'],
              pathex=[],
              binaries=[],
              datas=[('../../Nagstamon/resources', 'Nagstamon/resources')],
-             hiddenimports=[],
+             hiddenimports=hidden_imports,
              hookspath=[],
              hooksconfig={},
              runtime_hooks=[],
              excludes=[],
-             win_no_prefer_redirects=False,
-             win_private_assemblies=False,
-             cipher=block_cipher,
              noarchive=False)
-pyz = PYZ(a.pure, a.zipped_data,
-             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data)
 
 exe = EXE(pyz,
           a.scripts,
-          a.binaries,
-          a.zipfiles,
-          a.datas,
           [],
+          exclude_binaries=True,
           name='Nagstamon',
           debug=False,
           bootloader_ignore_signals=False,
           strip=False,
-          upx=True,
-          upx_exclude=[],
-          runtime_tmpdir=None,
+          # UPX is not supported on macOS arm64 and breaks the ad-hoc signature every
+          # arm64 binary needs to be startable at all
+          upx=False,
           console=False,
           codesign_identity=None,
           entitlements_file=None,
           icon='../../Nagstamon/resources/nagstamon.icns')
 
-# LSUIElement in info_plist hides the icon in dock
-app = BUNDLE(exe,
+# a one-dir bundle instead of a one-file bundle - macOS empties the /var/folders temp
+# directory a one-file bundle unpacks itself into while it is still running
+coll = COLLECT(exe,
+               a.binaries,
+               a.datas,
+               strip=False,
+               upx=False,
+               name='Nagstamon')
+
+info_plist = {
+    'CFBundleName': 'Nagstamon',
+    'CFBundleDisplayName': 'Nagstamon',
+    # without CFBundleVersion crash reports show the version as '???'
+    'CFBundleVersion': os.environ['NAGSTAMON_VERSION'],
+    'LSMinimumSystemVersion': minimum_system_version,
+    'NSHighResolutionCapable': True,
+    'NSRequiresAquaSystemAppearance': False,
+    'LSBackgroundOnly': False,
+    # LSUIElement hides the icon in dock
+    'LSUIElement': True
+}
+
+if ui_compatibility:
+    info_plist['UIDesignRequiresCompatibility'] = True
+
+app = BUNDLE(coll,
              name='Nagstamon.app',
              icon='../../Nagstamon/resources/nagstamon.icns',
              bundle_identifier='de.nagstamon',
              version=os.environ['NAGSTAMON_VERSION'],
-             info_plist={
-                'NSRequiresAquaSystemAppearance': False,
-                'LSBackgroundOnly': False,
-                'LSUIElement': True
-             })
+             info_plist=info_plist)

--- a/build/requirements/macos.txt
+++ b/build/requirements/macos.txt
@@ -1,13 +1,14 @@
 arrow
 beautifulsoup4
 cryptography
-# problems since 24.x?
-keyring==23.13.1
+keyring
 lxml
 packaging
 psutil
-pyinstaller
+pyinstaller==6.22.2
 pyobjc-framework-ApplicationServices
+# AppKit comes from Cocoa - it was only pulled in transitively before
+pyobjc-framework-Cocoa
 pyqt6==6.11.0
 pyqt6-qt6==6.11.1
 pyqt6-webengine==6.11.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ CLASSIFIERS = ['Intended Audience :: System Administrators',
                'Topic :: System :: Monitoring',
                'Topic :: System :: Networking :: Monitoring']
 
-# only used when building RPMs - stays empty on platforms which do not build any
+# only used when building RPMs - stays empty on the platforms which do not build them
 bdist_rpm_options = dict()
 
 # get paths of modules aka packages dynamically

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ NAGSTAMON_SCRIPT = 'nagstamon.py'
 
 from setuptools import setup
 
-os_dependent_include_files = ['Nagstamon/resources']
 if os.path.exists('nagstamon'):
     NAGSTAMON_SCRIPT = 'nagstamon'
 
@@ -70,22 +69,8 @@ CLASSIFIERS = ['Intended Audience :: System Administrators',
                'Topic :: System :: Monitoring',
                'Topic :: System :: Networking :: Monitoring']
 
-# Dependencies are automatically detected, but it might need
-# fine tuning.
-build_exe_options = dict(packages=['PyQt6.QtNetwork',
-                                   'keyring.backends.kwallet',
-                                   'keyring.backends.OS_X',
-                                   'keyring.backends.SecretService',
-                                   'keyring.backends.Windows'],
-                         include_files=os_dependent_include_files,
-                         include_msvcr=True,
-                         excludes=[])
-
-bdist_mac_options = dict(iconfile='Nagstamon/resources/nagstamon.icns',
-                         custom_info_plist='Nagstamon/resources/Info.plist')
-
-bdist_dmg_options = dict(volume_label='{0} {1}'.format(NAME, VERSION),
-                         applications_shortcut=False)
+# only used when building RPMs - stays empty on platforms which do not build any
+bdist_rpm_options = dict()
 
 # get paths of modules aka packages dynamically
 current_directory = Path().cwd()
@@ -158,8 +143,5 @@ setup(name=NAME,
       data_files=[(f'{sys.prefix}/share/man/man1', ['Nagstamon/resources/nagstamon.1.gz']),
                   (f'{sys.prefix}/share/pixmaps', ['Nagstamon/resources/nagstamon.svg']),
                   (f'{sys.prefix}/share/applications', ['Nagstamon/resources/nagstamon.desktop'])],
-      options=dict(build_exe=build_exe_options,
-                   bdist_mac=bdist_mac_options,
-                   bdist_dmg=bdist_dmg_options,
-                   bdist_rpm=bdist_rpm_options)
+      options=dict(bdist_rpm=bdist_rpm_options)
       )


### PR DESCRIPTION
This is about the macOS app bundle and the two macOS CI jobs. Three things, in one PR because they only make sense together.

### One-dir bundle instead of one-file

The bundle was built as a one-file bundle which unpacks itself into `/var/folders` at every start. macOS empties that directory while the application is still running, which is the reason the WAV files, the SVGs and `certifi/cacert.pem` have to be cached in memory and written back on demand (`helpers.py`, `servers/Generic.py`, see #578). A one-dir bundle does not have that problem and is also what PyInstaller recommends for `.app` bundles. The existing workarounds are left untouched, they check `os.path.exists()` first and simply become no-ops.

Along with it:

* `upx=False` - UPX is not supported on macOS arm64 and breaks the ad-hoc signature that every arm64 binary needs to be startable at all
* the finished bundle is signed ad-hoc. That is no replacement for a Developer ID signature and notarization, it just makes the bundle consistent and reproducibly startable
* `gssapi.raw` submodules are collected, as the Linux PyInstaller build already does - Nagstamon imports `gssapi.raw.cython_converters` on macOS
* `CFBundleName`, `CFBundleDisplayName`, `CFBundleVersion` and an explicit `NSHighResolutionCapable` in the Info.plist. Without `CFBundleVersion` macOS crash reports show the version as `???`, which is visible in most of the macOS crash reports in this tracker
* `UIDesignRequiresCompatibility` can be switched on with `NAGSTAMON_MACOS_UI_COMPAT=1` to build a bundle that keeps the pre-macOS-26 look instead of Liquid Glass. Off by default, this is just so both variants can be built and compared without patching the spec file
* the return codes of `pyinstaller` and `create-dmg` are checked - a failed build was silently treated as a success and uploaded
* the DMG volume icon uses the `.icns` instead of the Windows `.ico`
* `ARCH_MACOS_NAMES` is looked up with a fallback instead of raising `KeyError` on anything that is neither x86_64 nor arm64

`setup.py` raised a `NameError` on macOS because `bdist_rpm_options` is only assigned for non-Windows, non-Darwin platforms but referenced unconditionally. The dead cx_Freeze options next to it are removed - `setup.py` uses setuptools, and `bdist_mac_options` pointed at a `Nagstamon/resources/Info.plist` that does not exist in the repository.

### A minimum macOS version that is actually checked

There is no documented minimum macOS version, and the wheel tags are no help. `pyqt6-qt6` tags its arm64 wheel `macosx_11_0` and its x86_64 wheel `macosx_10_14`, while the Qt binaries inside both require macOS 13. Reading `LC_BUILD_VERSION` out of `QtCore` of the published wheels:

| pyqt6-qt6 | minos |
| --- | --- |
| 6.8.1, 6.9.2 | 12.0 |
| 6.10.0 and newer | 13.0 |

So the pin on 6.11.1 already requires macOS 13 without saying so anywhere, and a user on macOS 12 gets a dyld error instead of a useful message. macOS 13 is also what the Qt documentation lists as the oldest supported target for Qt 6.11, so that is what the bundle declares in `LSMinimumSystemVersion` now.

A declaration alone is a hope though, so `build/macos/check_deployment_target.py` walks every Mach-O file in the built bundle, reads the minimum macOS version out of `LC_BUILD_VERSION` and `LC_VERSION_MIN_MACOSX` and fails the build if anything needs more than the bundle claims. It catches the Qt binaries, but just as importantly the Python build: a Homebrew Python built on macOS 26 requires macOS 26, and building with it would quietly turn the DMG into a macOS-26-only download. That is not hypothetical, it is what happens when you run `build.py` on a current Homebrew Python today.

### CI

* `macos-arm` moves from `macos-14` to `macos-26` so the builds are made against the current SDK. `macos-intel` stays on `macos-15-intel` because macOS 26 only exists for arm64 runners
* both macOS jobs use `actions/setup-python` with a pinned version instead of the runner's own `python3`, which is unpinned and differs between the two runner images. This is not only about reproducibility - the deployment target of the Python build ends up in the app bundle and decides the oldest macOS the DMG runs on. The python.org builds that `actions/setup-python` installs target macOS 10.13 (x86_64) and 11.0 (arm64), well below the macOS 13 the Qt binaries need
* `MACOSX_DEPLOYMENT_TARGET` is set workflow wide and read by the spec file
* the deployment target check runs after each macOS build
* `--break-system-packages` is dropped, it is not needed once pip runs against the Python from setup-python

The macOS requirements lose the `keyring==23.13.1` pin, which carried a `# problems since 24.x?` comment from 2023 - keyring 25.7.0 works fine on macOS 26. `pyobjc-framework-Cocoa` is declared explicitly because `AppKit` is imported directly and only came in transitively so far, and `pyinstaller` gets pinned like the other build dependencies.

Built and verified locally on macOS 26.6.2 / Apple Silicon: bundle starts from the `.app`, `codesign --verify --deep --strict` passes, the Info.plist carries all the keys, and both Liquid Glass variants build.
