### PR TITLE
Alertmanager: fix silence handling for acknowledgements and downtimes

### DIFF
--- a/Nagstamon/config.py
+++ b/Nagstamon/config.py
@@ -1113,6 +1113,9 @@ class Server:
 
         # Alertmanager mappings
         self.alertmanager_filter = ''
+        # labels a silence created by Nagstamon matches on - all labels of an alert make
+        # the silence so specific that it breaks as soon as one volatile label changes
+        self.silence_matcher_labels = 'alertname,instance'
         self.map_to_critical = 'critical,error'
         self.map_to_warning = 'warning,warn'
         self.map_to_down = 'down'

--- a/Nagstamon/qui/dialogs/server.py
+++ b/Nagstamon/qui/dialogs/server.py
@@ -115,6 +115,8 @@ class DialogServer(Dialog):
             self.window.input_lineedit_map_to_status_information: ['Prometheus', 'Alertmanager'],
             self.window.label_alertmanager_filter: ['Alertmanager'],
             self.window.input_lineedit_alertmanager_filter: ['Alertmanager'],
+            self.window.label_silence_matcher_labels: ['Alertmanager'],
+            self.window.input_lineedit_silence_matcher_labels: ['Alertmanager'],
             self.window.label_map_to_ok: ['Alertmanager'],
             self.window.input_lineedit_map_to_ok: ['Alertmanager'],
             self.window.label_map_to_unknown: ['Alertmanager'],

--- a/Nagstamon/qui/widgets/treeview.py
+++ b/Nagstamon/qui/widgets/treeview.py
@@ -161,6 +161,9 @@ class TreeView(QTreeView):
     # tell worker to get status after a recheck has been solicited
     recheck = Signal(dict)
 
+    # tell worker to remove the silences suppressing an alert - Alertmanager only
+    remove_silence = Signal(dict)
+
     # tell notification that status of server has changed
     status_changed = Signal(str, str, str)
 
@@ -327,6 +330,9 @@ class TreeView(QTreeView):
 
         # connect signal for recheck action
         self.recheck.connect(self.worker.recheck)
+
+        # connect signal for removing silences - only Alertmanager knows them
+        self.remove_silence.connect(self.worker.remove_silence)
 
         # execute action by worker
         self.request_action.connect(self.worker.execute_action)
@@ -651,6 +657,13 @@ class TreeView(QTreeView):
             action_downtime.triggered.connect(self.action_downtime)
             self.action_menu.addAction(action_downtime)
 
+        # special menu entry for Alertmanager - acknowledgement and downtime both create
+        # a silence, so there has to be a way to get rid of one again
+        if self.server.type == 'Alertmanager':
+            action_remove_silence = QAction('Remove silence', self)
+            action_remove_silence.triggered.connect(self.action_remove_silence)
+            self.action_menu.addAction(action_remove_silence)
+
         # special menu entry for Checkmk Multisite for archiving events
         if self.server.type == 'Checkmk Multisite' and len(list_rows) == 1:
             if miserable_service == 'Events':
@@ -730,6 +743,7 @@ class TreeView(QTreeView):
             # default actions need closed statuswindow to display own dialogs
             if not conf.fullscreen and not conf.windowed and \
                     not method.__name__ == 'action_recheck' and \
+                    not method.__name__ == 'action_remove_silence' and \
                     not method.__name__ == 'action_archive_event':
                 self.action_menu_clicked.emit()
             # clear the right-click selection so the row doesn't remain
@@ -772,6 +786,22 @@ class TreeView(QTreeView):
             # send signal to worker recheck slot
             self.recheck.emit({'host': miserable_host,
                                'service': miserable_service})
+
+    @action_response_decorator
+    def action_remove_silence(self):
+        # How many rows we have
+        list_rows = []
+        for index in self.selectedIndexes():
+            if index.row() not in list_rows:
+                list_rows.append(index.row())
+
+        for lrow in list_rows:
+            miserable_host = self.model().data(self.model().createIndex(lrow, 0), Qt.ItemDataRole.DisplayRole)
+            miserable_service = self.model().data(self.model().createIndex(lrow, 2), Qt.ItemDataRole.DisplayRole)
+
+            # send signal to worker remove_silence slot
+            self.remove_silence.emit({'host': miserable_host,
+                                      'service': miserable_service})
 
     @action_response_decorator
     def action_acknowledge(self):
@@ -1364,6 +1394,19 @@ class TreeView(QTreeView):
 
             # call server recheck method
             self.server.set_recheck(info_dict)
+
+        @Slot(dict)
+        def remove_silence(self, info_dict):
+            """
+            Slot to expire the silences of an alert, getting signal from the context menu
+            """
+            if conf.debug_mode:
+                self.server.debug(server=self.server.name,
+                                  debug='Removing silences of {0} on {1}'.format(info_dict['service'],
+                                                                                 info_dict['host']))
+            # only Alertmanager knows silences at all
+            if hasattr(self.server, 'remove_silences'):
+                self.server.remove_silences(info_dict['host'], info_dict['service'])
 
         @Slot()
         def recheck_all(self):

--- a/Nagstamon/resources/qui/settings_server.ui
+++ b/Nagstamon/resources/qui/settings_server.ui
@@ -304,6 +304,16 @@
       <item row="16" column="2" colspan="3">
        <widget class="QLineEdit" name="input_lineedit_alertmanager_filter"/>
       </item>
+      <item row="38" column="1">
+       <widget class="QLabel" name="label_silence_matcher_labels">
+        <property name="text">
+         <string>Silence matcher labels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="38" column="2" colspan="3">
+       <widget class="QLineEdit" name="input_lineedit_silence_matcher_labels"/>
+      </item>
       <item row="36" column="2" colspan="3">
        <widget class="QLineEdit" name="input_lineedit_idp_ecp_endpoint"/>
       </item>
@@ -854,6 +864,7 @@
   <tabstop>input_lineedit_notification_lookback</tabstop>
   <tabstop>input_lineedit_custom_filter</tabstop>
   <tabstop>input_lineedit_alertmanager_filter</tabstop>
+  <tabstop>input_lineedit_silence_matcher_labels</tabstop>
   <tabstop>input_lineedit_map_to_hostname</tabstop>
   <tabstop>input_lineedit_map_to_servicename</tabstop>
   <tabstop>input_lineedit_map_to_status_information</tabstop>

--- a/Nagstamon/servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/servers/Alertmanager/alertmanagerserver.py
@@ -477,7 +477,7 @@ class AlertmanagerServer(GenericServer):
             service (str): The display name of the alert
 
         Returns:
-            int: How many silences were expired
+            int: How many silences were really expired
         """
         alert = self.get_alert(host, service)
         if alert is None:
@@ -485,9 +485,18 @@ class AlertmanagerServer(GenericServer):
         if not alert.silenced_by:
             log.info('no silence to remove for "%s" on "%s"', service, host)
             return 0
+        expired = 0
         for silence_id in alert.silenced_by:
-            self.expire_silence(silence_id)
-        return len(alert.silenced_by)
+            result = self.expire_silence(silence_id)
+            # a failed expiration leaves the alert suppressed, so it must not be counted
+            # as a success - otherwise the alert silently stays away until the next refresh
+            if result.error or not 200 <= result.status_code < 300:
+                log.error('could not expire silence "%s" of "%s" on "%s": %s',
+                          silence_id, service, host,
+                          result.error or f'status code {result.status_code}, {result.result}')
+                continue
+            expired += 1
+        return expired
 
     def _set_downtime(self, host, service, author, comment, fixed, start_time,
                       end_time, hours, minutes):

--- a/Nagstamon/servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/servers/Alertmanager/alertmanagerserver.py
@@ -3,6 +3,7 @@ import json
 import re
 
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
 
 from Nagstamon.config import conf
 from Nagstamon.objects import (GenericHost, Result)
@@ -10,9 +11,11 @@ from Nagstamon.servers.Generic import GenericServer
 from Nagstamon.helpers import webbrowser_open
 
 from .helpers import (start_logging,
+                      add_duration_to_timestring,
                       get_duration,
                       convert_timestring_to_utc,
-                      detect_from_labels)
+                      detect_from_labels,
+                      split_matchers)
 
 from .alertmanagerservice import AlertmanagerService
 
@@ -25,7 +28,7 @@ class AlertmanagerServer(GenericServer):
     """
     TYPE = 'Alertmanager'
 
-    # alertmanager actions are limited to visiting the monitor for now
+    # acknowledgement and downtime are both mapped onto silences
     MENU_ACTIONS = ['Monitor', 'Downtime', 'Acknowledge']
     BROWSER_URLS = {
         'monitor':  '$MONITOR$/#/alerts',
@@ -34,9 +37,11 @@ class AlertmanagerServer(GenericServer):
         'history':  '$MONITOR$/#/alerts'
     }
 
-    API_PATH_ALERTS = "/api/v2/alerts?inhibited=false"
+    API_PATH_ALERTS = "/api/v2/alerts"
     API_PATH_SILENCES = "/api/v2/silences"
-    API_FILTERS = '&filter='
+
+    # how long a silence lasts which was created by an acknowledgement without expiry time
+    DEFAULT_SILENCE_HOURS = 24
 
     # vars specific to alertmanager class
     map_to_hostname = ''
@@ -49,6 +54,7 @@ class AlertmanagerServer(GenericServer):
     map_to_ok = ''
     name = ''
     alertmanager_filter = ''
+    silence_matcher_labels = ''
 
 
     def init_http(self):
@@ -143,7 +149,7 @@ class AlertmanagerServer(GenericServer):
             acknowledged = False
             log.debug("[%s]: detected status: '%s'", fingerprint, attempt)
 
-        duration = str(get_duration(alert["startsAt"]))
+        duration = get_duration(alert.get("startsAt"))
 
         annotations = alert.get("annotations", {})
         status_information = detect_from_labels(annotations,self.map_to_status_information,'')
@@ -153,7 +159,7 @@ class AlertmanagerServer(GenericServer):
         result['server'] = self.name
         result['status'] = severity
         result['labels'] = labels
-        result['last_check'] = str(get_duration(alert["updatedAt"]))
+        result['last_check'] = get_duration(alert.get("updatedAt"))
         result['attempt'] = attempt
         result['scheduled_downtime'] = scheduled_downtime
         result['acknowledged'] = acknowledged
@@ -164,6 +170,21 @@ class AlertmanagerServer(GenericServer):
 
         return result
 
+
+    def get_alerts_url(self):
+        """Builds the URL to get the alerts from
+
+        The configured filter may contain several matchers separated by commas, which the
+        API expects as repeated filter parameters. Everything gets encoded properly - the
+        filter expressions contain characters like " and = which have to be escaped.
+
+        Returns:
+            str: The URL to fetch the alerts from
+        """
+        parameters = [('inhibited', 'false')]
+        parameters += [('filter', matcher)
+                       for matcher in split_matchers(self.alertmanager_filter)]
+        return f'{self.monitor_url}{self.API_PATH_ALERTS}?{urlencode(parameters)}'
 
     def _get_status(self):
         """
@@ -191,12 +212,7 @@ class AlertmanagerServer(GenericServer):
 
         # get all alerts from the API server
         try:
-            if self.alertmanager_filter != '':
-                result = self.fetch_url(self.monitor_url + self.API_PATH_ALERTS + self.API_FILTERS
-                                        + self.alertmanager_filter, giveback="raw")
-            else:
-                result = self.fetch_url(self.monitor_url + self.API_PATH_ALERTS,
-                                        giveback="raw")
+            result = self.fetch_url(self.get_alerts_url(), giveback="raw")
 
             if result.status_code == 200:
                 log.debug("received status code '%s' with this content in result.result: \n\
@@ -218,6 +234,14 @@ class AlertmanagerServer(GenericServer):
             errors_occured = self.check_for_error(data, error, status_code)
             if errors_occured is not None:
                 return errors_occured
+
+            # anything but a list of alerts means the request did not deliver what it
+            # should - iterating over it would walk the keys of an error object
+            if not isinstance(data, list):
+                log.error("expected a list of alerts but got '%s'", type(data).__name__)
+                return Result(result=result.result,
+                              error='Unexpected response from Alertmanager API',
+                              status_code=status_code)
 
             for alert in data:
                 alert_data = self._process_alert(alert)
@@ -272,38 +296,102 @@ class AlertmanagerServer(GenericServer):
         webbrowser_open(url)
 
 
+    def get_alert(self, host, service):
+        """Looks up an alert by the display name the GUI passes around
+
+        Services are keyed by fingerprint internally, but the GUI passes display_name.
+
+        Args:
+            host (str): The host the alert belongs to
+            service (str): The display name of the alert
+
+        Returns:
+            AlertmanagerService: The alert or None if it could not be found
+        """
+        if host not in self.hosts:
+            log.error('host "%s" not found', host)
+            return None
+        alert = next((x for x in self.hosts[host].services.values()
+                      if x.display_name == service), None)
+        if alert is None:
+            log.error('service "%s" not found on host "%s"', service, host)
+        return alert
+
+    def get_silence_matchers(self, alert):
+        """Builds the matchers of a silence for the given alert
+
+        Using every label of an alert makes the silence so specific that it stops matching
+        as soon as one volatile label changes, so the labels to match on are configurable.
+        If none of the configured labels exists on the alert all labels are used, because
+        a silence without matchers would silence everything.
+
+        Args:
+            alert (AlertmanagerService): The alert to be silenced
+
+        Returns:
+            list(dict): The matchers for the silence
+        """
+        labels = alert.labels
+        wanted = [x.strip() for x in self.silence_matcher_labels.split(',') if x.strip()]
+        if wanted:
+            selected = {name: value for name, value in labels.items() if name in wanted}
+            if selected:
+                labels = selected
+            else:
+                log.warning('none of the labels %s found on the alert - '
+                            'falling back to all of its labels', wanted)
+        return [{'name': name,
+                 'value': value,
+                 'isRegex': False,
+                 'isEqual': True}
+                for name, value in labels.items()]
+
+    def post_silence(self, alert, author, comment, starts_at, ends_at):
+        """Creates a silence for the given alert
+
+        API Spec: https://github.com/prometheus/alertmanager/blob/master/api/v2/openapi.yaml
+
+        Args:
+            alert (AlertmanagerService): The alert to be silenced
+            author (str): Who created the silence
+            comment (str): Why the silence was created
+            starts_at (str): Start of the silence as ISO formatted UTC time string
+            ends_at (str): End of the silence as ISO formatted UTC time string
+
+        Returns:
+            Result: The result of the API call
+        """
+        silence_data = {'matchers': self.get_silence_matchers(alert),
+                        'startsAt': starts_at,
+                        'endsAt': ends_at,
+                        'comment': comment,
+                        'createdBy': author or 'Nagstamon'}
+        log.debug('creating silence: %s', silence_data)
+        # the content type is given explicitly instead of relying on the session headers
+        # from init_http() - while credentials have to be renewed fetch_url() falls back
+        # to a temporary session which does not carry them, and Alertmanager answers
+        # anything but application/json with 415
+        return self.fetch_url(self.monitor_url + self.API_PATH_SILENCES, giveback="raw",
+                              cgi_data=json.dumps(silence_data),
+                              headers={'Content-Type': 'application/json'})
+
     def _set_downtime(self, host, service, author, comment, fixed, start_time,
                       end_time, hours, minutes):
 
-        # Services are keyed by fingerprint internally, but the UI passes display_name.
-        # Look up the alert by display_name.
-        alert = next((s for s in self.hosts[host].services.values()
-                      if s.display_name == service), None)
+        alert = self.get_alert(host, service)
         if alert is None:
-            log.error(f'_set_downtime: service "{service}" not found on host "{host}"')
             return
 
         # Convert local dates to UTC
-        start_time_dt = convert_timestring_to_utc(start_time)
-        end_time_dt = convert_timestring_to_utc(end_time)
+        starts_at = convert_timestring_to_utc(start_time)
+        if fixed:
+            ends_at = convert_timestring_to_utc(end_time)
+        else:
+            # a flexible downtime has no end time in the dialog, just a duration
+            ends_at = add_duration_to_timestring(start_time, hours, minutes)
 
-        # API Spec: https://github.com/prometheus/alertmanager/blob/master/api/v2/openapi.yaml
-        silence_data = {}
-        silence_data["matchers"] = []
-        for name, value in alert.labels.items():
-            silence_data["matchers"].append({
-                "name": name,
-                "value": value,
-                "isRegex": False,
-                "isEqual": True
-            })
-        silence_data["startsAt"] = start_time_dt
-        silence_data["endsAt"] = end_time_dt
-        silence_data["comment"] = comment or "Nagstamon downtime"
-        silence_data["createdBy"] = author or "Nagstamon"
-
-        self.fetch_url(self.monitor_url + self.API_PATH_SILENCES, giveback="raw",
-                       cgi_data=json.dumps(silence_data))
+        self.post_silence(alert, author, comment or 'Nagstamon downtime',
+                          starts_at, ends_at)
 
 
     # Overwrite function from generic server to add expire_time value
@@ -331,41 +419,27 @@ class AlertmanagerServer(GenericServer):
                               info_dict['expire_time'])
 
 
-    def _post_silence(self, alert, author, comment, starts_at, ends_at):
-        """Build and POST a silence payload for the given alert object."""
-        silence_data = {
-            "matchers": [
-                {"name": name, "value": value, "isRegex": False}
-                for name, value in alert.labels.items()
-            ],
-            "startsAt": starts_at,
-            "endsAt": ends_at,
-            "comment": comment or "Nagstamon silence",
-            "createdBy": author or "Nagstamon",
-        }
-        return self.fetch_url(self.monitor_url + self.API_PATH_SILENCES, giveback="raw",
-                              cgi_data=json.dumps(silence_data))
-
     def _set_acknowledge(self, host, service, author, comment, sticky, notify, persistent,
                          all_services=None, expire_time=None):
-        # Services are keyed by fingerprint internally, but the UI passes display_name.
-        # Look up the alert by display_name.
-        alert = next((s for s in self.hosts[host].services.values()
-                      if s.display_name == service), None)
+        alert = self.get_alert(host, service)
         if alert is None:
-            log.error(f'_set_acknowledge: service "{service}" not found on host "{host}"')
             return
 
-        starts_at = datetime.now(timezone.utc).isoformat()
-        ends_at = convert_timestring_to_utc(expire_time) if expire_time else starts_at
+        now = datetime.now(timezone.utc)
+        starts_at = now.isoformat()
+        if expire_time:
+            ends_at = convert_timestring_to_utc(expire_time)
+        else:
+            # without an end time the silence used to start and end at the very same
+            # moment, which silenced exactly nothing
+            ends_at = (now + timedelta(hours=self.DEFAULT_SILENCE_HOURS)).isoformat()
 
-        self._post_silence(alert, author, comment, starts_at, ends_at)
+        comment = comment or 'Nagstamon acknowledgement'
 
-        if all_services:
-            for svc_name in all_services:
-                svc_alert = next((s for s in self.hosts[host].services.values()
-                                  if s.display_name == svc_name), None)
-                if svc_alert is None:
-                    log.error(f'_set_acknowledge: service "{svc_name}" not found on host "{host}"')
-                    continue
-                self._post_silence(svc_alert, author, comment, starts_at, ends_at)
+        self.post_silence(alert, author, comment, starts_at, ends_at)
+
+        for service_name in all_services or []:
+            service_alert = self.get_alert(host, service_name)
+            if service_alert is None:
+                continue
+            self.post_silence(service_alert, author, comment, starts_at, ends_at)

--- a/Nagstamon/servers/Alertmanager/alertmanagerserver.py
+++ b/Nagstamon/servers/Alertmanager/alertmanagerserver.py
@@ -39,9 +39,15 @@ class AlertmanagerServer(GenericServer):
 
     API_PATH_ALERTS = "/api/v2/alerts"
     API_PATH_SILENCES = "/api/v2/silences"
+    API_PATH_SILENCE = "/api/v2/silence"
 
     # how long a silence lasts which was created by an acknowledgement without expiry time
     DEFAULT_SILENCE_HOURS = 24
+
+    # Alertmanager only knows silences, so the comment tells afterwards whether a silence
+    # was meant as an acknowledgement or as a downtime
+    SILENCE_COMMENT_ACKNOWLEDGE = 'Nagstamon acknowledgement'
+    SILENCE_COMMENT_DOWNTIME = 'Nagstamon downtime'
 
     # vars specific to alertmanager class
     map_to_hostname = ''
@@ -134,16 +140,15 @@ class AlertmanagerServer(GenericServer):
         servicename = detect_from_labels(labels,self.map_to_servicename,"unknown")
         log.debug("[%s]: detected servicename from labels: '%s'", fingerprint, servicename)
 
-        if "status" in alert:
-            attempt = alert["status"].get("state", "unknown")
-        else:
-            attempt = "unknown"
+        alert_status = alert.get("status", {})
+        attempt = alert_status.get("state", "unknown")
+        silenced_by = alert_status.get("silencedBy", []) or []
 
         if attempt == "suppressed":
             scheduled_downtime = True
             acknowledged = True
-            log.debug("[%s]: detected status: '%s' -> interpreting as silenced",
-                      fingerprint, attempt)
+            log.debug("[%s]: detected status: '%s' -> interpreting as silenced by %s",
+                      fingerprint, attempt, silenced_by)
         else:
             scheduled_downtime = False
             acknowledged = False
@@ -167,6 +172,7 @@ class AlertmanagerServer(GenericServer):
         result['generatorURL'] = generator_url
         result['fingerprint'] = fingerprint
         result['status_information'] = status_information
+        result['silenced_by'] = silenced_by
 
         return result
 
@@ -243,6 +249,9 @@ class AlertmanagerServer(GenericServer):
                               error='Unexpected response from Alertmanager API',
                               status_code=status_code)
 
+            # alerts suppressed by a silence get a second look further down
+            suppressed_services = []
+
             for alert in data:
                 alert_data = self._process_alert(alert)
                 if not alert_data:
@@ -263,14 +272,20 @@ class AlertmanagerServer(GenericServer):
 
                 service.generator_url = alert_data['generatorURL']
                 service.fingerprint = alert_data['fingerprint']
+                service.silenced_by = alert_data['silenced_by']
 
                 service.status_information = alert_data['status_information']
+
+                if service.silenced_by:
+                    suppressed_services.append(service)
 
                 if service.host not in self.new_hosts:
                     self.new_hosts[service.host] = GenericHost()
                     self.new_hosts[service.host].name = str(service.host)
                     self.new_hosts[service.host].server = self.name
                 self.new_hosts[service.host].services[service.name] = service
+
+            self.apply_silence_kind(suppressed_services)
 
         except Exception as the_exception:
             # set checking flag back to False
@@ -281,6 +296,35 @@ class AlertmanagerServer(GenericServer):
 
         # dummy return in case all is OK
         return Result()
+
+    def apply_silence_kind(self, services):
+        """Tells acknowledgements and downtimes apart for the given silenced alerts
+
+        Alertmanager only knows silences, so a suppressed alert used to be marked as
+        acknowledged and in downtime at the same time, which makes the according filters
+        useless. The comment of the silence tells which of the two it was meant to be.
+        Silences created elsewhere keep counting as both.
+
+        Args:
+            services (list(AlertmanagerService)): The suppressed alerts
+        """
+        if not services:
+            return
+
+        silences = {silence.get('id'): silence for silence in self.get_silences()}
+        if not silences:
+            return
+
+        for service in services:
+            comments = [silences[silence_id].get('comment', '')
+                        for silence_id in service.silenced_by
+                        if silence_id in silences]
+            acknowledged = any(x.startswith(self.SILENCE_COMMENT_ACKNOWLEDGE) for x in comments)
+            downtime = any(x.startswith(self.SILENCE_COMMENT_DOWNTIME) for x in comments)
+            # only decide if at least one silence was created by Nagstamon
+            if acknowledged or downtime:
+                service.acknowledged = acknowledged
+                service.scheduled_downtime = downtime
 
     def open_monitor_webpage(self, host, service):
         """
@@ -375,6 +419,76 @@ class AlertmanagerServer(GenericServer):
                               cgi_data=json.dumps(silence_data),
                               headers={'Content-Type': 'application/json'})
 
+    @staticmethod
+    def build_silence_comment(marker, comment):
+        """Prefixes the user comment with the marker telling what the silence stands for
+
+        Args:
+            marker (str): One of SILENCE_COMMENT_ACKNOWLEDGE or SILENCE_COMMENT_DOWNTIME
+            comment (str): The comment the user entered, may be empty
+
+        Returns:
+            str: The comment to send along with the silence
+        """
+        if comment:
+            return f'{marker}: {comment}'
+        return marker
+
+    def get_silences(self):
+        """Gets all silences known to the Alertmanager
+
+        Returns:
+            list(dict): The silences, empty if they could not be retrieved
+        """
+        result = self.fetch_url(self.monitor_url + self.API_PATH_SILENCES, giveback="raw")
+        try:
+            silences = json.loads(result.result)
+        except json.decoder.JSONDecodeError:
+            log.error("could not decode the silences: %s", result.result)
+            return []
+        if not isinstance(silences, list):
+            log.error("expected a list of silences but got '%s'", type(silences).__name__)
+            return []
+        return silences
+
+    def expire_silence(self, silence_id):
+        """Expires a single silence
+
+        Args:
+            silence_id (str): ID of the silence to expire
+
+        Returns:
+            Result: The result of the API call
+        """
+        log.debug("expiring silence '%s'", silence_id)
+        return self.fetch_url(f'{self.monitor_url}{self.API_PATH_SILENCE}/{silence_id}',
+                              giveback="raw",
+                              method="DELETE")
+
+    def remove_silences(self, host, service):
+        """Expires all silences which suppress the given alert
+
+        This is the counterpart of the acknowledgement and the downtime, both of which
+        create a silence. Without it a silence could only be removed in the Alertmanager
+        web interface.
+
+        Args:
+            host (str): The host the alert belongs to
+            service (str): The display name of the alert
+
+        Returns:
+            int: How many silences were expired
+        """
+        alert = self.get_alert(host, service)
+        if alert is None:
+            return 0
+        if not alert.silenced_by:
+            log.info('no silence to remove for "%s" on "%s"', service, host)
+            return 0
+        for silence_id in alert.silenced_by:
+            self.expire_silence(silence_id)
+        return len(alert.silenced_by)
+
     def _set_downtime(self, host, service, author, comment, fixed, start_time,
                       end_time, hours, minutes):
 
@@ -390,7 +504,8 @@ class AlertmanagerServer(GenericServer):
             # a flexible downtime has no end time in the dialog, just a duration
             ends_at = add_duration_to_timestring(start_time, hours, minutes)
 
-        self.post_silence(alert, author, comment or 'Nagstamon downtime',
+        self.post_silence(alert, author,
+                          self.build_silence_comment(self.SILENCE_COMMENT_DOWNTIME, comment),
                           starts_at, ends_at)
 
 
@@ -434,7 +549,7 @@ class AlertmanagerServer(GenericServer):
             # moment, which silenced exactly nothing
             ends_at = (now + timedelta(hours=self.DEFAULT_SILENCE_HOURS)).isoformat()
 
-        comment = comment or 'Nagstamon acknowledgement'
+        comment = self.build_silence_comment(self.SILENCE_COMMENT_ACKNOWLEDGE, comment)
 
         self.post_silence(alert, author, comment, starts_at, ends_at)
 

--- a/Nagstamon/servers/Alertmanager/alertmanagerservice.py
+++ b/Nagstamon/servers/Alertmanager/alertmanagerservice.py
@@ -9,6 +9,8 @@ class AlertmanagerService(GenericService):
     def __init__(self):
         super().__init__()
         self.labels = {}
+        # IDs of the silences which suppress this alert - needed to expire them again
+        self.silenced_by = []
 
     def get_service_name(self):
         return self.display_name

--- a/Nagstamon/servers/Alertmanager/helpers.py
+++ b/Nagstamon/servers/Alertmanager/helpers.py
@@ -25,12 +25,19 @@ def get_duration(timestring):
     format) until now and returns a human friendly string
 
     Args:
-        timestring (string): An ISO8601 time string 
+        timestring (string): An ISO8601 time string
 
     Returns:
-        string: A time string in human readable format
+        string: A time string in human readable format, empty if the given time string is
+                missing or unparseable - not every Alertmanager implementation delivers
+                all timestamps
     """
-    time_object = dateutil.parser.parse(timestring)
+    if not timestring:
+        return ""
+    try:
+        time_object = dateutil.parser.parse(timestring)
+    except (ValueError, OverflowError, TypeError):
+        return ""
     duration = datetime.now(timezone.utc) - time_object
     hour = int(duration.seconds / 3600)
     minute = int(duration.seconds % 3600 / 60)
@@ -78,3 +85,55 @@ def detect_from_labels(labels, config_label_list, default_value="", list_delimit
             result = labels.get(each_label)
             break
     return result
+
+
+def add_duration_to_timestring(timestring, hours=0, minutes=0):
+    """Adds the given amount of time to a time string and returns it as UTC in ISO format
+
+    Args:
+        timestring (string): A time string in local time
+        hours (int): Hours to add
+        minutes (int): Minutes to add
+
+    Returns:
+        string: A time string in ISO format
+    """
+    local_time = datetime.now(timezone(timedelta(0))).astimezone().tzinfo
+    parsed_time = dateutil.parser.parse(timestring).replace(tzinfo=local_time)
+    end_time = parsed_time + timedelta(hours=int(hours), minutes=int(minutes))
+    return end_time.astimezone(timezone.utc).isoformat()
+
+
+def split_matchers(text, delimiter=","):
+    """Splits a filter expression into single matchers
+
+    A simple split() would break matchers whose value contains the delimiter, like
+    severity=~"warning,critical", so delimiters inside quotes are ignored.
+
+    Args:
+        text (string): The filter expression
+        delimiter (string, optional): The delimiter between matchers. Defaults to ",".
+
+    Returns:
+        list(str): The single matchers, stripped and without empty ones
+    """
+    matchers = []
+    current = ""
+    quote = None
+    for character in text:
+        if quote:
+            current += character
+            if character == quote:
+                quote = None
+        elif character in ('"', "'"):
+            quote = character
+            current += character
+        elif character == delimiter:
+            if current.strip():
+                matchers.append(current.strip())
+            current = ""
+        else:
+            current += character
+    if current.strip():
+        matchers.append(current.strip())
+    return matchers

--- a/Nagstamon/servers/Generic.py
+++ b/Nagstamon/servers/Generic.py
@@ -1481,7 +1481,8 @@ class GenericServer:
         # return True if all worked well
         return Result()
 
-    def fetch_url(self, url, giveback='obj', cgi_data=None, no_auth=False, multipart=False, headers=None):
+    def fetch_url(self, url, giveback='obj', cgi_data=None, no_auth=False, multipart=False, headers=None,
+                  method=None):
         """
         get content of given url, cgi_data only used if present
         'obj' fetch_url() gives back a dict full of miserable hosts/services,
@@ -1489,6 +1490,7 @@ class GenericServer:
         'raw' it gives back pure HTML - useful for finding out IP or new version
         'json' gives back JSON data
         existence of cgi_data forces urllib to use POST instead of GET requests
+        method allows any other HTTP method, for example DELETE
         NEW: gives back a list containing result and, if necessary, a more clear error description
         """
 
@@ -1547,7 +1549,10 @@ class GenericServer:
                         self.init_http()
                     # most requests come without multipart/form-data
                     if multipart is False:
-                        if cgi_data is None:
+                        if method:
+                            response = self.session.request(method, url, data=cgi_data, timeout=self.timeout,
+                                                            headers=headers)
+                        elif cgi_data is None:
                             response = self.session.get(url, timeout=self.timeout, headers=headers)
                         else:
                             response = self.session.post(url, data=cgi_data, timeout=self.timeout, headers=headers)
@@ -1576,7 +1581,10 @@ class GenericServer:
 
                     # most requests come without multipart/form-data
                     if not multipart:
-                        if cgi_data is None:
+                        if method:
+                            response = temporary_session.request(method, url, data=cgi_data, timeout=self.timeout,
+                                                                 verify=False, headers=headers)
+                        elif cgi_data is None:
                             response = temporary_session.get(url, timeout=self.timeout, verify=False, headers=headers)
                         else:
                             response = temporary_session.post(url, data=cgi_data, timeout=self.timeout, verify=False, headers=headers)

--- a/Nagstamon/servers/Generic.py
+++ b/Nagstamon/servers/Generic.py
@@ -1525,14 +1525,16 @@ class GenericServer:
                         file.write(self.cacert_content)
 
                 # in case we know the server's encoding use it
-                if self.encoding:
-                    if cgi_data is not None:
-                        try:
-                            for k in cgi_data:
-                                cgi_data[k] = cgi_data[k].encode(self.encoding)
-                        except:
-                            # set to false to mark it as invalid
-                            self.encoding = False
+                # servers which hand over an already serialized body, like the JSON of the
+                # Alertmanager silences, pass a string - iterating over that as if it was
+                # a dict raised a TypeError on every request and disabled the encoding
+                if self.encoding and isinstance(cgi_data, dict):
+                    try:
+                        for k in cgi_data:
+                            cgi_data[k] = cgi_data[k].encode(self.encoding)
+                    except:
+                        # set to false to mark it as invalid
+                        self.encoding = False
 
                 # use session only for connections to monitor servers, other requests like looking for updates
                 # should go out without credentials

--- a/Nagstamon/servers/__init__.py
+++ b/Nagstamon/servers/__init__.py
@@ -214,6 +214,7 @@ def create_server(server=None):
 
     # Prometheus & Alertmanager
     new_server.alertmanager_filter = server.alertmanager_filter
+    new_server.silence_matcher_labels = server.silence_matcher_labels
     new_server.map_to_hostname = server.map_to_hostname
     new_server.map_to_servicename = server.map_to_servicename
     new_server.map_to_status_information = server.map_to_status_information

--- a/tests/test_alertmanager.py
+++ b/tests/test_alertmanager.py
@@ -44,6 +44,7 @@ class test_alertmanager(unittest.TestCase):
         self.assertEqual(test_result['labels'], {"alertname":"Error","device":"murpel","endpoint":"metrics","instance":"127.0.0.1:9100","job":"node-exporter","namespace":"monitoring","pod":"monitoring-prometheus-node-exporter-4711","prometheus":"monitoring/monitoring-prometheus-oper-prometheus","service":"monitoring-prometheus-node-exporter","severity":"warning"})
         self.assertEqual(test_result['generatorURL'], 'http://localhost')
         self.assertEqual(test_result['fingerprint'], '0ef7c4bd7a504b8d')
+        self.assertEqual(test_result['silenced_by'], ['bb043288-42a0-4315-8bae-15cde1d7e239'])
         self.assertEqual(test_result['status_information'], 'Network interface "murpel" showing errors on node-exporter monitoring/monitoring-prometheus-node-exporter-4711')
 
 
@@ -281,7 +282,8 @@ class test_alertmanager_silences(unittest.TestCase):
         silence = self.requests[0]['cgi_data']
         self.assertEqual(self.requests[0]['url'], 'http://localhost:9093/api/v2/silences')
         self.assertEqual(silence['createdBy'], 'someone')
-        self.assertEqual(silence['comment'], 'because')
+        # the marker tells an acknowledgement from a downtime when reading it back
+        self.assertEqual(silence['comment'], 'Nagstamon acknowledgement: because')
 
         duration = (dateutil.parser.parse(silence['endsAt'])
                     - dateutil.parser.parse(silence['startsAt']))
@@ -339,3 +341,84 @@ class test_alertmanager_silences(unittest.TestCase):
         self.server._set_downtime('nosuchhost', 'Error', 'someone', 'maintenance', True,
                                   '2026-09-01 10:00:00', '2026-09-01 12:00:00', 0, 0)
         self.assertEqual(self.requests, [])
+
+
+class test_alertmanager_silence_removal(unittest.TestCase):
+    """acknowledgement, downtime and their removal all end up as silences"""
+
+    def setUp(self):
+        self.expired = []
+
+        self.server = AlertmanagerServer()
+        self.server.monitor_url = 'http://localhost:9093'
+
+        self.alert = AlertmanagerService()
+        self.alert.display_name = 'Error'
+        self.alert.labels = {'alertname': 'Error'}
+        self.alert.silenced_by = ['silence-1', 'silence-2']
+
+        host = GenericHost()
+        host.name = '127.0.0.1'
+        host.services = {'0ef7c4bd7a504b8d': self.alert}
+        self.server.hosts = {'127.0.0.1': host}
+
+        self.server.expire_silence = self.expired.append
+
+    def test_build_silence_comment(self):
+        self.assertEqual(
+            AlertmanagerServer.build_silence_comment('Nagstamon downtime', 'because'),
+            'Nagstamon downtime: because')
+        self.assertEqual(
+            AlertmanagerServer.build_silence_comment('Nagstamon downtime', ''),
+            'Nagstamon downtime')
+
+    def test_remove_silences_expires_all_of_them(self):
+        self.assertEqual(self.server.remove_silences('127.0.0.1', 'Error'), 2)
+        self.assertEqual(self.expired, ['silence-1', 'silence-2'])
+
+    def test_remove_silences_without_silence(self):
+        self.alert.silenced_by = []
+        self.assertEqual(self.server.remove_silences('127.0.0.1', 'Error'), 0)
+        self.assertEqual(self.expired, [])
+
+    def test_remove_silences_of_unknown_alert(self):
+        self.assertEqual(self.server.remove_silences('127.0.0.1', 'Nope'), 0)
+        self.assertEqual(self.expired, [])
+
+    def test_acknowledgement_and_downtime_are_told_apart(self):
+        """a suppressed alert used to be acknowledged and in downtime at the same time"""
+        self.server.get_silences = lambda: [
+            {'id': 'silence-1', 'comment': 'Nagstamon downtime: maintenance'}]
+        self.alert.silenced_by = ['silence-1']
+        self.alert.acknowledged = True
+        self.alert.scheduled_downtime = True
+
+        self.server.apply_silence_kind([self.alert])
+
+        self.assertFalse(self.alert.acknowledged)
+        self.assertTrue(self.alert.scheduled_downtime)
+
+    def test_acknowledgement_marker(self):
+        self.server.get_silences = lambda: [
+            {'id': 'silence-1', 'comment': 'Nagstamon acknowledgement: because'}]
+        self.alert.silenced_by = ['silence-1']
+        self.alert.acknowledged = True
+        self.alert.scheduled_downtime = True
+
+        self.server.apply_silence_kind([self.alert])
+
+        self.assertTrue(self.alert.acknowledged)
+        self.assertFalse(self.alert.scheduled_downtime)
+
+    def test_foreign_silence_stays_both(self):
+        """silences created outside of Nagstamon cannot be told apart"""
+        self.server.get_silences = lambda: [
+            {'id': 'silence-1', 'comment': 'silenced via the web interface'}]
+        self.alert.silenced_by = ['silence-1']
+        self.alert.acknowledged = True
+        self.alert.scheduled_downtime = True
+
+        self.server.apply_silence_kind([self.alert])
+
+        self.assertTrue(self.alert.acknowledged)
+        self.assertTrue(self.alert.scheduled_downtime)

--- a/tests/test_alertmanager.py
+++ b/tests/test_alertmanager.py
@@ -5,7 +5,7 @@ import dateutil.parser
 from pylint import lint
 
 import unittest
-from Nagstamon.objects import GenericHost
+from Nagstamon.objects import GenericHost, Result
 from Nagstamon.servers.Alertmanager import (AlertmanagerServer,
                                             AlertmanagerService)
 
@@ -362,7 +362,13 @@ class test_alertmanager_silence_removal(unittest.TestCase):
         host.services = {'0ef7c4bd7a504b8d': self.alert}
         self.server.hosts = {'127.0.0.1': host}
 
-        self.server.expire_silence = self.expired.append
+        def expire_silence(silence_id):
+            self.expired.append(silence_id)
+            return Result(result='', status_code=self.status_codes.get(silence_id, 200))
+
+        # status code the faked API answers with, per silence
+        self.status_codes = {}
+        self.server.expire_silence = expire_silence
 
     def test_build_silence_comment(self):
         self.assertEqual(
@@ -384,6 +390,12 @@ class test_alertmanager_silence_removal(unittest.TestCase):
     def test_remove_silences_of_unknown_alert(self):
         self.assertEqual(self.server.remove_silences('127.0.0.1', 'Nope'), 0)
         self.assertEqual(self.expired, [])
+
+    def test_remove_silences_does_not_count_a_failed_one(self):
+        self.status_codes['silence-1'] = 404
+        self.assertEqual(self.server.remove_silences('127.0.0.1', 'Error'), 1)
+        # the failing one must not stop the others from being expired
+        self.assertEqual(self.expired, ['silence-1', 'silence-2'])
 
     def test_acknowledgement_and_downtime_are_told_apart(self):
         """a suppressed alert used to be acknowledged and in downtime at the same time"""

--- a/tests/test_alertmanager.py
+++ b/tests/test_alertmanager.py
@@ -1,9 +1,13 @@
 import json
+from datetime import datetime, timedelta
 
+import dateutil.parser
 from pylint import lint
 
 import unittest
-from Nagstamon.servers.Alertmanager import AlertmanagerServer
+from Nagstamon.objects import GenericHost
+from Nagstamon.servers.Alertmanager import (AlertmanagerServer,
+                                            AlertmanagerService)
 
 conf = {}
 conf['debug_mode'] = True
@@ -23,7 +27,7 @@ class test_alertmanager(unittest.TestCase):
         test_class.map_to_hostname = 'instance,pod_name,namespace'
         test_class.map_to_servicename = 'alertname'
         test_class.map_to_status_information = 'message,summary,description'
-        test_class.map_to_unknwon = ''
+        test_class.map_to_unknown = ''
         test_class.map_to_critical = ''
         test_class.map_to_warning = ''
         test_class.map_to_ok = ''
@@ -65,7 +69,7 @@ class test_alertmanager(unittest.TestCase):
         test_class.map_to_hostname = 'instance,pod_name,namespace'
         test_class.map_to_servicename = 'alertname'
         test_class.map_to_status_information = 'message,summary,description'
-        test_class.map_to_unknwon = ''
+        test_class.map_to_unknown = ''
         test_class.map_to_critical = ''
         test_class.map_to_warning = ''
         test_class.map_to_ok = ''
@@ -93,7 +97,7 @@ class test_alertmanager(unittest.TestCase):
         test_class.map_to_hostname = 'instance,pod_name,namespace'
         test_class.map_to_servicename = 'alertname'
         test_class.map_to_status_information = 'message,summary,description'
-        test_class.map_to_unknwon = ''
+        test_class.map_to_unknown = ''
         test_class.map_to_critical = ''
         test_class.map_to_warning = ''
         test_class.map_to_ok = ''
@@ -121,7 +125,7 @@ class test_alertmanager(unittest.TestCase):
         test_class.map_to_hostname = ''
         test_class.map_to_servicename = ''
         test_class.map_to_status_information = ''
-        test_class.map_to_unknwon = ''
+        test_class.map_to_unknown = ''
         test_class.map_to_critical = ''
         test_class.map_to_warning = ''
         test_class.map_to_ok = ''
@@ -149,7 +153,7 @@ class test_alertmanager(unittest.TestCase):
         test_class.map_to_hostname = 'instance,pod_name,namespace'
         test_class.map_to_servicename = 'alertname'
         test_class.map_to_status_information = 'message,summary,description'
-        test_class.map_to_unknwon = 'unknown'
+        test_class.map_to_unknown = 'unknown'
         test_class.map_to_critical = 'error,rocketchat'
         test_class.map_to_warning = 'warning'
         test_class.map_to_ok = 'ok'
@@ -171,3 +175,167 @@ class test_alertmanager(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+    def test_unit_alert_without_timestamps(self):
+        """not every Alertmanager implementation delivers all timestamps"""
+        with open('tests/test_alertmanager_warning.json') as json_file:
+            data = json.load(json_file)
+        del data['startsAt']
+        del data['updatedAt']
+
+        test_class = AlertmanagerServer()
+        test_class.map_to_hostname = 'instance,pod_name,namespace'
+        test_class.map_to_servicename = 'alertname'
+        test_class.map_to_status_information = 'message,summary,description'
+        test_class.map_to_unknown = ''
+        test_class.map_to_critical = ''
+        test_class.map_to_warning = ''
+        test_class.map_to_ok = ''
+
+        test_result = test_class._process_alert(data)
+
+        self.assertEqual(test_result['duration'], '')
+        self.assertEqual(test_result['last_check'], '')
+        self.assertEqual(test_result['status'], 'WARNING')
+
+
+    def test_unit_get_alerts_url(self):
+        test_class = AlertmanagerServer()
+        test_class.monitor_url = 'http://localhost:9093'
+
+        test_class.alertmanager_filter = ''
+        self.assertEqual(test_class.get_alerts_url(),
+                         'http://localhost:9093/api/v2/alerts?inhibited=false')
+
+        # a single filter has to be encoded, it contains " and =
+        test_class.alertmanager_filter = 'severity="critical"'
+        self.assertEqual(test_class.get_alerts_url(),
+                         'http://localhost:9093/api/v2/alerts?'
+                         'inhibited=false&filter=severity%3D%22critical%22')
+
+        # several matchers become several filter parameters
+        test_class.alertmanager_filter = 'severity="critical", job="node"'
+        self.assertEqual(test_class.get_alerts_url(),
+                         'http://localhost:9093/api/v2/alerts?inhibited=false'
+                         '&filter=severity%3D%22critical%22&filter=job%3D%22node%22')
+
+        # a comma inside a quoted value does not split the matcher
+        test_class.alertmanager_filter = 'severity=~"warning,critical"'
+        self.assertEqual(test_class.get_alerts_url(),
+                         'http://localhost:9093/api/v2/alerts?inhibited=false'
+                         '&filter=severity%3D~%22warning%2Ccritical%22')
+
+
+    def test_unit_silence_matchers(self):
+        test_class = AlertmanagerServer()
+        alert = AlertmanagerService()
+        alert.labels = {'alertname': 'Error', 'instance': '127.0.0.1:9100', 'pod': 'volatile-4711'}
+
+        # only the configured labels are used
+        test_class.silence_matcher_labels = 'alertname,instance'
+        matchers = test_class.get_silence_matchers(alert)
+        self.assertEqual([x['name'] for x in matchers], ['alertname', 'instance'])
+        self.assertTrue(all(x['isEqual'] and not x['isRegex'] for x in matchers))
+
+        # without configured labels all of them are used
+        test_class.silence_matcher_labels = ''
+        self.assertEqual(len(test_class.get_silence_matchers(alert)), 3)
+
+        # a silence without matchers would silence everything, so unknown labels fall back
+        test_class.silence_matcher_labels = 'does_not_exist'
+        self.assertEqual(len(test_class.get_silence_matchers(alert)), 3)
+
+
+class test_alertmanager_silences(unittest.TestCase):
+    """tests for the silences Nagstamon creates - fetch_url is replaced by a recorder"""
+
+    def setUp(self):
+        self.requests = []
+
+        self.server = AlertmanagerServer()
+        self.server.monitor_url = 'http://localhost:9093'
+        self.server.silence_matcher_labels = 'alertname'
+
+        self.alert = AlertmanagerService()
+        self.alert.display_name = 'Error'
+        self.alert.labels = {'alertname': 'Error', 'instance': '127.0.0.1:9100'}
+
+        host = GenericHost()
+        host.name = '127.0.0.1'
+        host.services = {'0ef7c4bd7a504b8d': self.alert}
+        self.server.hosts = {'127.0.0.1': host}
+
+        def fetch_url(url, giveback=None, cgi_data=None, **kwargs):
+            self.requests.append({'url': url, 'cgi_data': json.loads(cgi_data)})
+            return None
+
+        self.server.fetch_url = fetch_url
+
+    def test_acknowledge_without_expire_time_lasts(self):
+        """without an end time the silence used to end at the very moment it started"""
+        self.server._set_acknowledge('127.0.0.1', 'Error', 'someone', 'because',
+                                     False, False, False)
+
+        self.assertEqual(len(self.requests), 1)
+        silence = self.requests[0]['cgi_data']
+        self.assertEqual(self.requests[0]['url'], 'http://localhost:9093/api/v2/silences')
+        self.assertEqual(silence['createdBy'], 'someone')
+        self.assertEqual(silence['comment'], 'because')
+
+        duration = (dateutil.parser.parse(silence['endsAt'])
+                    - dateutil.parser.parse(silence['startsAt']))
+        self.assertEqual(duration, timedelta(hours=AlertmanagerServer.DEFAULT_SILENCE_HOURS))
+
+    def test_acknowledge_with_expire_time(self):
+        # the acknowledge dialog hands over a local time in this format
+        expire_time = (datetime.now() + timedelta(hours=4)).strftime('%Y-%m-%dT%H:%M:%S')
+        self.server._set_acknowledge('127.0.0.1', 'Error', 'someone', 'because',
+                                     False, False, False,
+                                     expire_time=expire_time)
+
+        silence = self.requests[0]['cgi_data']
+        duration = (dateutil.parser.parse(silence['endsAt'])
+                    - dateutil.parser.parse(silence['startsAt']))
+        # the exact seconds depend on when the test runs
+        self.assertAlmostEqual(duration.total_seconds(),
+                               timedelta(hours=4).total_seconds(),
+                               delta=5)
+
+    def test_acknowledge_all_services(self):
+        other = AlertmanagerService()
+        other.display_name = 'Warning'
+        other.labels = {'alertname': 'Warning'}
+        self.server.hosts['127.0.0.1'].services['abcdef'] = other
+
+        self.server._set_acknowledge('127.0.0.1', 'Error', 'someone', 'because',
+                                     False, False, False, all_services=['Warning'])
+
+        self.assertEqual(len(self.requests), 2)
+        self.assertEqual(self.requests[1]['cgi_data']['matchers'][0]['value'], 'Warning')
+
+    def test_downtime_fixed_uses_end_time(self):
+        self.server._set_downtime('127.0.0.1', 'Error', 'someone', 'maintenance', True,
+                                  '2026-09-01 10:00:00', '2026-09-01 12:00:00', 0, 0)
+
+        silence = self.requests[0]['cgi_data']
+        duration = (dateutil.parser.parse(silence['endsAt'])
+                    - dateutil.parser.parse(silence['startsAt']))
+        self.assertEqual(duration, timedelta(hours=2))
+
+    def test_downtime_flexible_uses_duration(self):
+        """hours and minutes used to be accepted and then ignored"""
+        self.server._set_downtime('127.0.0.1', 'Error', 'someone', 'maintenance', False,
+                                  '2026-09-01 10:00:00', '2026-09-01 12:00:00', 3, 30)
+
+        silence = self.requests[0]['cgi_data']
+        duration = (dateutil.parser.parse(silence['endsAt'])
+                    - dateutil.parser.parse(silence['startsAt']))
+        self.assertEqual(duration, timedelta(hours=3, minutes=30))
+
+    def test_unknown_service_does_not_raise(self):
+        self.server._set_acknowledge('127.0.0.1', 'Does Not Exist', 'someone', 'because',
+                                     False, False, False)
+        self.server._set_downtime('nosuchhost', 'Error', 'someone', 'maintenance', True,
+                                  '2026-09-01 10:00:00', '2026-09-01 12:00:00', 0, 0)
+        self.assertEqual(self.requests, [])


### PR DESCRIPTION
Acknowledgement and downtime in the Alertmanager server both create a silence, and there were a few problems with that.

**An acknowledgement without an expiry time did nothing.** `_set_acknowledge()` fell back to `ends_at = starts_at`, so the silence expired in the same moment it was created. It lasts 24 hours by default now.

**A flexible downtime ignored its duration.** `_set_downtime()` accepted `fixed`, `hours` and `minutes` and only ever used the end time from the dialog.

**The silence POST was rejected.** It went out as `application/octet-stream` and Alertmanager answers that with `415 unsupported media type`. `init_http()` does put the JSON content type on the session, but while credentials still have to be renewed `fetch_url()` falls back to a temporary session which does not carry the session headers, so the content type is passed per request now.

**Silences matched too narrowly.** They were built from every label of an alert, which makes them so specific that they stop matching as soon as one volatile label changes - a pod name is enough. The labels to match on are configurable now and default to `alertname,instance`. If none of them exists on the alert all labels are used, because a silence without matchers would silence everything.

**Silences could not be removed.** The silence IDs the API delivers in `status.silencedBy` were parsed and thrown away, and `/api/v2/silences` was only ever posted to. A silence set by accident could only be removed in the Alertmanager web interface. The alerts carry their silence IDs now and a "Remove silence" entry in the context menu expires them, following the same pattern as the Checkmk specific "Archive event" entry. `fetch_url()` got a `method` parameter for the DELETE so it goes through the usual session, proxy and error handling instead of reaching for `self.session` directly.

**A suppressed alert was acknowledged and in downtime at the same time**, which makes both of the according filters useless. Nagstamon writes what it meant into the silence comment now and evaluates it when reading the alerts back. Silences created elsewhere keep counting as both, there is nothing to tell them apart by.

A few more robustness fixes in the same file:

* the alert filter was appended to the URL unencoded, so the `"` and `=` of a matcher went out raw, and only one matcher was possible. Filters are encoded now and a comma separated list becomes several `filter` parameters, with commas inside quoted values not splitting a matcher
* `startsAt` and `updatedAt` were indexed directly and raise a `KeyError` when missing, which the repository's own `test_alertmanager_skipped.json` fixture already provokes
* a response that is not a list of alerts was iterated over anyway, walking the keys of an error object
* `_set_downtime()` and `_set_acknowledge()` built their silence payload separately and disagreed about `isEqual`
* `fetch_url()` iterated `cgi_data` as if it were always a dict. The Alertmanager passes serialized JSON, so every silence POST raised a `TypeError` internally and disabled the server encoding as a side effect
* the module logger wrote to stdout only and read `conf.debug_mode` once at import time, so its output never reached the debug window or the debug file and switching the debug mode at runtime had no effect - there was a TODO about that in the file. The level is decided per record now and a second handler hands the records to the debug queue

Every existing test set `map_to_unknwon` instead of `map_to_unknown`, so that mapping was never actually exercised. Tests were added for the URL building, the silence matchers, the silence durations, the removal and alerts without timestamps.

Verified against a real Alertmanager 0.34: acknowledging marks the alert acknowledged only, a downtime marks it in downtime only, and removing the silence brings the alert back as active.
