### PR TITLE
Fix missing Authorization header for servers added in the settings dialog

### DIFF
--- a/Nagstamon/servers/Zabbix.py
+++ b/Nagstamon/servers/Zabbix.py
@@ -66,8 +66,6 @@ class ZabbixServer(GenericServer):
         self.use_description_name_service = conf.servers[self.get_name()].use_description_name_service
         self.api_version = ''
         self.auth_token = ''
-        # Force authentication refresh by default until verified
-        self.refresh_authentication = True
         self.monitor_path = '/api_jsonrpc.php'
 
     def init_config(self):

--- a/Nagstamon/servers/__init__.py
+++ b/Nagstamon/servers/__init__.py
@@ -172,11 +172,6 @@ def create_server(server=None):
     # ECP authentication
     new_server.idp_ecp_endpoint = server.idp_ecp_endpoint
 
-    # if password is not to be saved ask for it at startup
-    if (server.enabled is True and server.save_password is False and
-            server.use_autologin is False):
-        new_server.refresh_authentication = True
-
     # Special FX
     # Centreon
     new_server.use_autologin = server.use_autologin
@@ -277,7 +272,5 @@ for server in conf.servers.values():
     created_server = create_server(server)
     if created_server is not None:
         servers[server.name] = created_server
-        # for the next time no auth needed
-        servers[server.name].refresh_authentication = False
 
 

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -4,7 +4,7 @@ Tests for the generic server creation in Nagstamon.servers
 
 import unittest
 
-from Nagstamon.config import Server
+from Nagstamon.config import Server, conf
 from Nagstamon.servers import create_server
 
 
@@ -48,6 +48,40 @@ class test_create_server(unittest.TestCase):
                                                 password='sometoken'))
         session = server.create_session()
         self.assertEqual(session.auth.token, 'sometoken')
+
+
+class test_create_zabbix_server(unittest.TestCase):
+    """
+    ZabbixServer.__init__() reads its configuration from conf.servers, so the
+    configuration has to be registered there before the server is created
+    """
+
+    def setUp(self):
+        server_conf = Server()
+        server_conf.name = 'test-zabbix'
+        server_conf.type = 'Zabbix'
+        server_conf.enabled = True
+        server_conf.monitor_url = 'http://localhost/zabbix'
+        server_conf.authentication = 'basic'
+        server_conf.username = 'someuser'
+        server_conf.password = 'somepassword'
+        server_conf.save_password = True
+        server_conf.use_autologin = False
+        self.server_conf = server_conf
+        conf.servers[server_conf.name] = server_conf
+
+    def tearDown(self):
+        conf.servers.pop(self.server_conf.name, None)
+
+    def test_credentials_are_not_suppressed(self):
+        """
+        a fresh Zabbix server used to set refresh_authentication in its constructor, which
+        made fetch_url() drop the session and the GUI report an authentication problem
+        before the first poll had even happened - init_http() calls check_authentication()
+        on every poll and assigns the flag itself, so the constructor must not preset it
+        """
+        server = create_server(self.server_conf)
+        self.assertFalse(server.refresh_authentication)
 
 
 if __name__ == '__main__':

--- a/tests/test_servers.py
+++ b/tests/test_servers.py
@@ -1,0 +1,54 @@
+"""
+Tests for the generic server creation in Nagstamon.servers
+"""
+
+import unittest
+
+from Nagstamon.config import Server
+from Nagstamon.servers import create_server
+
+
+class test_create_server(unittest.TestCase):
+
+    def make_config(self, **kwargs):
+        server_conf = Server()
+        server_conf.name = 'test'
+        server_conf.type = 'Alertmanager'
+        server_conf.enabled = True
+        server_conf.monitor_url = 'http://localhost:9093'
+        server_conf.authentication = 'basic'
+        server_conf.username = 'someuser'
+        server_conf.password = 'somepassword'
+        server_conf.use_autologin = False
+        for key, value in kwargs.items():
+            setattr(server_conf, key, value)
+        return server_conf
+
+    def test_credentials_are_not_suppressed_without_saved_password(self):
+        """
+        issue #1212 - a server which does not save its password was created with
+        refresh_authentication set, which makes fetch_url() send every request through a
+        session without any credentials
+        """
+        server = create_server(self.make_config(save_password=False))
+        self.assertFalse(server.refresh_authentication)
+
+    def test_credentials_are_not_suppressed_with_saved_password(self):
+        server = create_server(self.make_config(save_password=True))
+        self.assertFalse(server.refresh_authentication)
+
+    def test_session_carries_the_configured_credentials(self):
+        server = create_server(self.make_config(save_password=False))
+        session = server.create_session()
+        self.assertEqual(session.auth, (b'someuser', b'somepassword'))
+
+    def test_session_carries_a_bearer_token(self):
+        server = create_server(self.make_config(save_password=False,
+                                                authentication='bearer',
+                                                password='sometoken'))
+        session = server.create_session()
+        self.assertEqual(session.auth.token, 'sometoken')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`create_server()` sets `refresh_authentication` for every enabled server that does not save its password, which is the default for a newly added server:

```python
# if password is not to be saved ask for it at startup
if (server.enabled is True and server.save_password is False and
        server.use_autologin is False):
    new_server.refresh_authentication = True
```

While that flag is set, `fetch_url()` deliberately sends the request through a temporary session without any credentials:

```python
if no_auth is False and \
   not self.refresh_authentication or \
   no_auth is False and self.authentication == 'web':
    ...  # session with credentials
else:
    # send request without authentication data
    temporary_session = requests.Session()
```

So no Authorization header goes out at all - regardless of whether Basic Auth or a Bearer token is configured, which is what the issue describes.

At startup this stays invisible, because the loop that creates the servers resets the flag again a few lines later:

```python
for server in conf.servers.values():
    created_server = create_server(server)
    if created_server is not None:
        servers[server.name] = created_server
        # for the next time no auth needed
        servers[server.name].refresh_authentication = False
```

The settings dialog does not do that. `qui/dialogs/server.py` calls `create_server()` when a server is added or edited and puts the result straight into `servers`, so a server configured in the dialog keeps its credentials suppressed for the rest of the session. That is exactly the reproduction path in the issue - add a server, configure credentials, watch the requests arrive without an Authorization header - and it also explains why it looks erratic: after a restart the same server works, because then the startup loop clears the flag.

Since the assignment and the reset cancel each other out at startup and only do damage in the dialog path, both are removed.

Verified with the little HTTP listener from the issue:

| | before | after |
| --- | --- | --- |
| server from the startup loop | `Authorization: Basic c29tZXVzZXI6...` | unchanged |
| server from the settings dialog | `Authorization: None` | `Authorization: Basic c29tZXVzZXI6...` |

Bearer tokens behave the same way and arrive as `Authorization: Bearer <token>` now.

What the removed comment intended - asking for the password at startup when it is not saved - still happens, just through the regular path: the request goes out with the empty password, the monitor answers 401, and `get_status()` sets `refresh_authentication` so the GUI asks for credentials. Checked against a listener answering 401: the flag is set as before and `get_status()` returns 401, so the authentication dialog still comes up. Nothing in `fetch_url()` or in the authentication flow itself is touched.

A test covers the flag and the credentials ending up on the session; it fails without the change.

Fixes #1212
